### PR TITLE
ML-227:  Specify whether need to tell us about more than one site

### DIFF
--- a/src/api/exemptions/controllers/update-site-details.js
+++ b/src/api/exemptions/controllers/update-site-details.js
@@ -20,14 +20,20 @@ export const updateSiteDetailsController = {
     try {
       const { payload, db } = request
 
-      const { siteDetails, id, updatedAt, updatedBy } = payload
+      const { multipleSiteDetails, siteDetails, id, updatedAt, updatedBy } =
+        payload
 
-      const result = await db
-        .collection('exemptions')
-        .updateOne(
-          { _id: ObjectId.createFromHexString(id) },
-          { $set: { siteDetails, updatedAt, updatedBy } }
-        )
+      const result = await db.collection('exemptions').updateOne(
+        { _id: ObjectId.createFromHexString(id) },
+        {
+          $set: {
+            ...(multipleSiteDetails && { multipleSiteDetails }),
+            siteDetails,
+            updatedAt,
+            updatedBy
+          }
+        }
+      )
 
       if (result.matchedCount === 0) {
         throw Boom.notFound('Exemption not found')

--- a/src/api/exemptions/controllers/update-site-details.test.js
+++ b/src/api/exemptions/controllers/update-site-details.test.js
@@ -1,6 +1,7 @@
 import { ObjectId } from 'mongodb'
 import { updateSiteDetailsController } from './update-site-details.js'
 import Boom from '@hapi/boom'
+import { mockMultipleSiteDetails } from '../../../models/site-details/test-fixtures.js'
 
 describe('PATCH /exemptions/site-details', () => {
   const payloadValidator = updateSiteDetailsController.options.validate.payload
@@ -19,7 +20,14 @@ describe('PATCH /exemptions/site-details', () => {
     const { mockMongo, mockHandler } = global
     const mockPayload = {
       id: new ObjectId().toHexString(),
-      siteDetails: {},
+      multipleSiteDetails: mockMultipleSiteDetails,
+      siteDetails: {
+        coordinatesType: 'coordinates',
+        coordinatesEntry: 'single',
+        coordinateSystem: 'wgs84',
+        coordinates: { latitude: '51.489676', longitude: '-0.231530' },
+        circleWidth: '20'
+      },
       ...mockAuditPayload
     }
 
@@ -47,6 +55,7 @@ describe('PATCH /exemptions/site-details', () => {
       { _id: ObjectId.createFromHexString(mockPayload.id) },
       {
         $set: {
+          multipleSiteDetails: mockPayload.multipleSiteDetails,
           siteDetails: mockPayload.siteDetails,
           ...mockAuditPayload
         }
@@ -58,7 +67,14 @@ describe('PATCH /exemptions/site-details', () => {
     const { mockMongo, mockHandler } = global
     const mockPayload = {
       id: new ObjectId().toHexString(),
-      siteDetails: {},
+      multipleSiteDetails: mockMultipleSiteDetails,
+      siteDetails: {
+        coordinatesType: 'coordinates',
+        coordinatesEntry: 'single',
+        coordinateSystem: 'wgs84',
+        coordinates: { latitude: '51.489676', longitude: '-0.231530' },
+        circleWidth: '20'
+      },
       ...mockAuditPayload
     }
 
@@ -85,7 +101,14 @@ describe('PATCH /exemptions/site-details', () => {
     const { mockMongo, mockHandler } = global
     const mockPayload = {
       id: new ObjectId().toHexString(),
-      siteDetails: {},
+      multipleSiteDetails: mockMultipleSiteDetails,
+      siteDetails: {
+        coordinatesType: 'coordinates',
+        coordinatesEntry: 'single',
+        coordinateSystem: 'wgs84',
+        coordinates: { latitude: '51.489676', longitude: '-0.231530' },
+        circleWidth: '20'
+      },
       ...mockAuditPayload
     }
 

--- a/src/models/site-details/multiple-site-details.js
+++ b/src/models/site-details/multiple-site-details.js
@@ -1,0 +1,5 @@
+import joi from 'joi'
+
+export const multipleSiteDetailsSchema = joi.object({
+  multipleSitesEnabled: joi.boolean().default(false)
+})

--- a/src/models/site-details/multiple-site-details.js
+++ b/src/models/site-details/multiple-site-details.js
@@ -1,5 +1,7 @@
 import joi from 'joi'
 
 export const multipleSiteDetailsSchema = joi.object({
-  multipleSitesEnabled: joi.boolean().default(false)
+  multipleSitesEnabled: joi.boolean().default(false).messages({
+    'boolean.base': 'MULTIPLE_SITES_REQUIRED'
+  })
 })

--- a/src/models/site-details/multiple-site-details.test.js
+++ b/src/models/site-details/multiple-site-details.test.js
@@ -43,9 +43,7 @@ describe('multipleSiteDetailsSchema', () => {
       })
 
       expect(result.error).toBeDefined()
-      expect(result.error.message).toContain(
-        '"multipleSitesEnabled" must be a boolean'
-      )
+      expect(result.error.message).toContain('MULTIPLE_SITES_REQUIRED')
     })
 
     it('should fail when multipleSitesEnabled is a number', () => {
@@ -53,9 +51,7 @@ describe('multipleSiteDetailsSchema', () => {
         multipleSitesEnabled: 1
       })
 
-      expect(result.error.message).toContain(
-        '"multipleSitesEnabled" must be a boolean'
-      )
+      expect(result.error.message).toContain('MULTIPLE_SITES_REQUIRED')
     })
 
     it('should fail when multipleSitesEnabled is null', () => {
@@ -63,9 +59,7 @@ describe('multipleSiteDetailsSchema', () => {
         multipleSitesEnabled: null
       })
 
-      expect(result.error.message).toContain(
-        '"multipleSitesEnabled" must be a boolean'
-      )
+      expect(result.error.message).toContain('MULTIPLE_SITES_REQUIRED')
     })
   })
 })

--- a/src/models/site-details/multiple-site-details.test.js
+++ b/src/models/site-details/multiple-site-details.test.js
@@ -1,0 +1,71 @@
+import { multipleSiteDetailsSchema } from './multiple-site-details.js'
+
+describe('multipleSiteDetailsSchema', () => {
+  describe('when multipleSitesEnabled is provided', () => {
+    it('should validate when multipleSitesEnabled is true', () => {
+      const result = multipleSiteDetailsSchema.validate({
+        multipleSitesEnabled: true
+      })
+
+      expect(result.error).toBeUndefined()
+      expect(result.value).toEqual({
+        multipleSitesEnabled: true
+      })
+    })
+
+    it('should validate when multipleSitesEnabled is false', () => {
+      const result = multipleSiteDetailsSchema.validate({
+        multipleSitesEnabled: false
+      })
+
+      expect(result.error).toBeUndefined()
+      expect(result.value).toEqual({
+        multipleSitesEnabled: false
+      })
+    })
+  })
+
+  describe('when multipleSitesEnabled is not provided', () => {
+    it('should default multipleSitesEnabled to false', () => {
+      const result = multipleSiteDetailsSchema.validate({})
+
+      expect(result.error).toBeUndefined()
+      expect(result.value).toEqual({
+        multipleSitesEnabled: false
+      })
+    })
+  })
+
+  describe('when multipleSitesEnabled has invalid values', () => {
+    it('should fail when multipleSitesEnabled is a string', () => {
+      const result = multipleSiteDetailsSchema.validate({
+        multipleSitesEnabled: 'maybe'
+      })
+
+      expect(result.error).toBeDefined()
+      expect(result.error.message).toContain(
+        '"multipleSitesEnabled" must be a boolean'
+      )
+    })
+
+    it('should fail when multipleSitesEnabled is a number', () => {
+      const result = multipleSiteDetailsSchema.validate({
+        multipleSitesEnabled: 1
+      })
+
+      expect(result.error.message).toContain(
+        '"multipleSitesEnabled" must be a boolean'
+      )
+    })
+
+    it('should fail when multipleSitesEnabled is null', () => {
+      const result = multipleSiteDetailsSchema.validate({
+        multipleSitesEnabled: null
+      })
+
+      expect(result.error.message).toContain(
+        '"multipleSitesEnabled" must be a boolean'
+      )
+    })
+  })
+})

--- a/src/models/site-details/site-details.js
+++ b/src/models/site-details/site-details.js
@@ -21,8 +21,23 @@ import {
   s3LocationFieldSchema
 } from './file-upload.js'
 
+const multipleSitesEnabledSchema = joi.boolean().default(false)
+
 export const siteDetailsSchema = joi
   .object({
+    multipleSiteDetails: joi.when('siteDetails.coordinatesType', {
+      is: 'coordinates',
+      then: joi
+        .object({
+          multipleSitesEnabled: multipleSitesEnabledSchema
+        })
+        .required(),
+      otherwise: joi
+        .object({
+          multipleSitesEnabled: multipleSitesEnabledSchema
+        })
+        .optional()
+    }),
     siteDetails: joi
       .object({
         coordinatesType: coordinatesTypeFieldSchema,

--- a/src/models/site-details/site-details.js
+++ b/src/models/site-details/site-details.js
@@ -20,23 +20,14 @@ import {
   uploadedFileFieldSchema,
   s3LocationFieldSchema
 } from './file-upload.js'
-
-const multipleSitesEnabledSchema = joi.boolean().default(false)
+import { multipleSiteDetailsSchema } from './multiple-site-details.js'
 
 export const siteDetailsSchema = joi
   .object({
     multipleSiteDetails: joi.when('siteDetails.coordinatesType', {
       is: 'coordinates',
-      then: joi
-        .object({
-          multipleSitesEnabled: multipleSitesEnabledSchema
-        })
-        .required(),
-      otherwise: joi
-        .object({
-          multipleSitesEnabled: multipleSitesEnabledSchema
-        })
-        .optional()
+      then: multipleSiteDetailsSchema.required(),
+      otherwise: multipleSiteDetailsSchema.optional()
     }),
     siteDetails: joi
       .object({

--- a/src/models/site-details/site-details.test.js
+++ b/src/models/site-details/site-details.test.js
@@ -6,9 +6,7 @@ import {
   mockOsgb36MultipleCoordinatesRequest,
   mockId,
   mockSiteDetails,
-  mockSiteDetailsRequest,
-  mockMultipleSiteDetails,
-  mockMultipleSiteDetailsEnabled
+  mockSiteDetailsRequest
 } from './test-fixtures.js'
 
 describe('#siteDetails schema', () => {
@@ -33,39 +31,9 @@ describe('#siteDetails schema', () => {
     })
   })
 
-  describe('#multipleSiteDetails', () => {
+  describe('#multipleSiteDetails integration', () => {
     describe('when coordinatesType is "coordinates"', () => {
-      test('Should correctly validate when multipleSitesEnabled is explicitly false', () => {
-        const result = siteDetailsSchema.validate(mockSiteDetailsRequest)
-        expect(result.error).toBeUndefined()
-        expect(result.value.multipleSiteDetails.multipleSitesEnabled).toBe(
-          false
-        )
-      })
-
-      test('Should correctly validate when multipleSitesEnabled is true', () => {
-        const requestWithTrue = {
-          ...mockSiteDetailsRequest,
-          multipleSiteDetails: mockMultipleSiteDetailsEnabled
-        }
-        const result = siteDetailsSchema.validate(requestWithTrue)
-        expect(result.error).toBeUndefined()
-        expect(result.value.multipleSiteDetails.multipleSitesEnabled).toBe(true)
-      })
-
-      test('Should default multipleSitesEnabled to false when not provided in object', () => {
-        const requestWithEmptyObject = {
-          ...mockSiteDetailsRequest,
-          multipleSiteDetails: {}
-        }
-        const result = siteDetailsSchema.validate(requestWithEmptyObject)
-        expect(result.error).toBeUndefined()
-        expect(result.value.multipleSiteDetails.multipleSitesEnabled).toBe(
-          false
-        )
-      })
-
-      test('Should reject when multipleSiteDetails is missing', () => {
+      test('Should require multipleSiteDetails when coordinatesType is coordinates', () => {
         const requestWithoutMultipleSiteDetails = {
           id: mockId,
           siteDetails: mockSiteDetails
@@ -75,48 +43,14 @@ describe('#siteDetails schema', () => {
         )
         expect(result.error.message).toBe('"multipleSiteDetails" is required')
       })
-
-      test('Should reject when multipleSitesEnabled is null', () => {
-        const requestWithNull = {
-          ...mockSiteDetailsRequest,
-          multipleSiteDetails: { multipleSitesEnabled: null }
-        }
-        const result = siteDetailsSchema.validate(requestWithNull)
-        expect(result.error.message).toBe(
-          '"multipleSiteDetails.multipleSitesEnabled" must be a boolean'
-        )
-      })
-
-      test('Should reject when multipleSitesEnabled is non-boolean', () => {
-        const requestWithString = {
-          ...mockSiteDetailsRequest,
-          multipleSiteDetails: { multipleSitesEnabled: 'maybe' }
-        }
-        const result = siteDetailsSchema.validate(requestWithString)
-        expect(result.error.message).toBe(
-          '"multipleSiteDetails.multipleSitesEnabled" must be a boolean'
-        )
-      })
     })
 
     describe('when coordinatesType is "file"', () => {
-      test('Should correctly validate when multipleSiteDetails is not provided', () => {
+      test('Should allow multipleSiteDetails to be optional when coordinatesType is file', () => {
         const result = siteDetailsSchema.validate(
           mockFileUploadSiteDetailsRequest
         )
         expect(result.error).toBeUndefined()
-      })
-
-      test('Should correctly validate when multipleSitesEnabled is explicitly false', () => {
-        const requestWithFalse = {
-          ...mockFileUploadSiteDetailsRequest,
-          multipleSiteDetails: mockMultipleSiteDetails
-        }
-        const result = siteDetailsSchema.validate(requestWithFalse)
-        expect(result.error).toBeUndefined()
-        expect(result.value.multipleSiteDetails.multipleSitesEnabled).toBe(
-          false
-        )
       })
     })
   })

--- a/src/models/site-details/site-details.test.js
+++ b/src/models/site-details/site-details.test.js
@@ -6,7 +6,9 @@ import {
   mockOsgb36MultipleCoordinatesRequest,
   mockId,
   mockSiteDetails,
-  mockSiteDetailsRequest
+  mockSiteDetailsRequest,
+  mockMultipleSiteDetails,
+  mockMultipleSiteDetailsEnabled
 } from './test-fixtures.js'
 
 describe('#siteDetails schema', () => {
@@ -28,6 +30,94 @@ describe('#siteDetails schema', () => {
     test('Should correctly validate on invalid data', () => {
       const result = siteDetailsSchema.validate({ id: mockId })
       expect(result.error.message).toBe('SITE_DETAILS_REQUIRED')
+    })
+  })
+
+  describe('#multipleSiteDetails', () => {
+    describe('when coordinatesType is "coordinates"', () => {
+      test('Should correctly validate when multipleSitesEnabled is explicitly false', () => {
+        const result = siteDetailsSchema.validate(mockSiteDetailsRequest)
+        expect(result.error).toBeUndefined()
+        expect(result.value.multipleSiteDetails.multipleSitesEnabled).toBe(
+          false
+        )
+      })
+
+      test('Should correctly validate when multipleSitesEnabled is true', () => {
+        const requestWithTrue = {
+          ...mockSiteDetailsRequest,
+          multipleSiteDetails: mockMultipleSiteDetailsEnabled
+        }
+        const result = siteDetailsSchema.validate(requestWithTrue)
+        expect(result.error).toBeUndefined()
+        expect(result.value.multipleSiteDetails.multipleSitesEnabled).toBe(true)
+      })
+
+      test('Should default multipleSitesEnabled to false when not provided in object', () => {
+        const requestWithEmptyObject = {
+          ...mockSiteDetailsRequest,
+          multipleSiteDetails: {}
+        }
+        const result = siteDetailsSchema.validate(requestWithEmptyObject)
+        expect(result.error).toBeUndefined()
+        expect(result.value.multipleSiteDetails.multipleSitesEnabled).toBe(
+          false
+        )
+      })
+
+      test('Should reject when multipleSiteDetails is missing', () => {
+        const requestWithoutMultipleSiteDetails = {
+          id: mockId,
+          siteDetails: mockSiteDetails
+        }
+        const result = siteDetailsSchema.validate(
+          requestWithoutMultipleSiteDetails
+        )
+        expect(result.error.message).toBe('"multipleSiteDetails" is required')
+      })
+
+      test('Should reject when multipleSitesEnabled is null', () => {
+        const requestWithNull = {
+          ...mockSiteDetailsRequest,
+          multipleSiteDetails: { multipleSitesEnabled: null }
+        }
+        const result = siteDetailsSchema.validate(requestWithNull)
+        expect(result.error.message).toBe(
+          '"multipleSiteDetails.multipleSitesEnabled" must be a boolean'
+        )
+      })
+
+      test('Should reject when multipleSitesEnabled is non-boolean', () => {
+        const requestWithString = {
+          ...mockSiteDetailsRequest,
+          multipleSiteDetails: { multipleSitesEnabled: 'maybe' }
+        }
+        const result = siteDetailsSchema.validate(requestWithString)
+        expect(result.error.message).toBe(
+          '"multipleSiteDetails.multipleSitesEnabled" must be a boolean'
+        )
+      })
+    })
+
+    describe('when coordinatesType is "file"', () => {
+      test('Should correctly validate when multipleSiteDetails is not provided', () => {
+        const result = siteDetailsSchema.validate(
+          mockFileUploadSiteDetailsRequest
+        )
+        expect(result.error).toBeUndefined()
+      })
+
+      test('Should correctly validate when multipleSitesEnabled is explicitly false', () => {
+        const requestWithFalse = {
+          ...mockFileUploadSiteDetailsRequest,
+          multipleSiteDetails: mockMultipleSiteDetails
+        }
+        const result = siteDetailsSchema.validate(requestWithFalse)
+        expect(result.error).toBeUndefined()
+        expect(result.value.multipleSiteDetails.multipleSitesEnabled).toBe(
+          false
+        )
+      })
     })
   })
 

--- a/src/models/site-details/test-fixtures.js
+++ b/src/models/site-details/test-fixtures.js
@@ -3,6 +3,14 @@ import { COORDINATE_SYSTEMS } from '../../common/constants/coordinates.js'
 
 const mockId = new ObjectId().toHexString()
 
+export const mockMultipleSiteDetails = {
+  multipleSitesEnabled: false
+}
+
+export const mockMultipleSiteDetailsEnabled = {
+  multipleSitesEnabled: true
+}
+
 export const mockSiteDetails = {
   coordinatesType: 'coordinates',
   coordinatesEntry: 'single',
@@ -13,6 +21,7 @@ export const mockSiteDetails = {
 
 export const mockSiteDetailsRequest = {
   id: mockId,
+  multipleSiteDetails: mockMultipleSiteDetails,
   siteDetails: mockSiteDetails
 }
 
@@ -92,11 +101,13 @@ export const mockOsgb36MultipleCoordinates = {
 
 export const mockWgs84MultipleCoordinatesRequest = {
   id: mockId,
+  multipleSiteDetails: mockMultipleSiteDetails,
   siteDetails: mockWgs84MultipleCoordinates
 }
 
 export const mockOsgb36MultipleCoordinatesRequest = {
   id: mockId,
+  multipleSiteDetails: mockMultipleSiteDetails,
   siteDetails: mockOsgb36MultipleCoordinates
 }
 

--- a/src/models/site-details/test-fixtures.js
+++ b/src/models/site-details/test-fixtures.js
@@ -7,10 +7,6 @@ export const mockMultipleSiteDetails = {
   multipleSitesEnabled: false
 }
 
-export const mockMultipleSiteDetailsEnabled = {
-  multipleSitesEnabled: true
-}
-
 export const mockSiteDetails = {
   coordinatesType: 'coordinates',
   coordinatesEntry: 'single',


### PR DESCRIPTION
- Store multipleSiteDetails in exemption.
- This will be used to save multi site field choices made on the frontend, which here is multipleSitesEnabled but more will be added in future user stories.
- siteDetails will become an array in a future user story which will actually store the data based on the choices.

```
        "multipleSiteDetails": {
            "multipleSitesEnabled": false
        },
        "siteDetails": {
            "coordinatesType": "coordinates",
            "coordinatesEntry": "multiple",
            "coordinateSystem": "wgs84",
            "coordinates": [
                {
                    "latitude": "54.088594",
                    "longitude": "-0.178408"
                },
                {
                    "latitude": "54.086782",
                    "longitude": "-0.177369"
                },
                {
                    "latitude": "54.088057",
                    "longitude": "-0.175219"
                }
            ]
        }
```