### PR TITLE
ML-488 - Don't get exemption type label from DB

### DIFF
--- a/src/api/exemptions/controllers/create-project-name.js
+++ b/src/api/exemptions/controllers/create-project-name.js
@@ -2,10 +2,7 @@ import Boom from '@hapi/boom'
 import { projectName as projectNameSchema } from '../../../models/project-name.js'
 import { StatusCodes } from 'http-status-codes'
 import { getContactId } from '../helpers/get-contact-id.js'
-import {
-  EXEMPTION_STATUS,
-  EXEMPTION_TYPE
-} from '../../../common/constants/exemption.js'
+import { EXEMPTION_STATUS } from '../../../common/constants/exemption.js'
 
 export const createProjectNameController = {
   options: {
@@ -33,7 +30,6 @@ export const createProjectNameController = {
         updatedBy,
         updatedAt,
         status: EXEMPTION_STATUS.DRAFT,
-        type: EXEMPTION_TYPE.EXEMPT_ACTIVITY,
         contactId
       })
 

--- a/src/api/exemptions/controllers/create-project-name.test.js
+++ b/src/api/exemptions/controllers/create-project-name.test.js
@@ -1,9 +1,6 @@
 import { createProjectNameController } from './create-project-name'
 import { ObjectId } from 'mongodb'
-import {
-  EXEMPTION_STATUS,
-  EXEMPTION_TYPE
-} from '../../../common/constants/exemption.js'
+import { EXEMPTION_STATUS } from '../../../common/constants/exemption.js'
 
 describe('POST /exemptions/project-name', () => {
   const payloadValidator = createProjectNameController.options.validate.payload
@@ -72,7 +69,6 @@ describe('POST /exemptions/project-name', () => {
     expect(mockInsertOne).toHaveBeenCalledWith({
       projectName: 'Test Project',
       status: EXEMPTION_STATUS.DRAFT,
-      type: EXEMPTION_TYPE.EXEMPT_ACTIVITY,
       contactId: expect.any(String),
       ...mockAuditPayload
     })

--- a/src/api/exemptions/controllers/get-exemptions.js
+++ b/src/api/exemptions/controllers/get-exemptions.js
@@ -1,24 +1,14 @@
 import { StatusCodes } from 'http-status-codes'
 import { getContactId } from '../helpers/get-contact-id.js'
-import {
-  EXEMPTION_STATUS,
-  EXEMPTION_TYPE
-} from '../../../common/constants/exemption.js'
+import { EXEMPTION_STATUS } from '../../../common/constants/exemption.js'
 
 const transformedExemptions = (exemptions) =>
   exemptions.map((exemption) => {
-    const {
-      _id,
-      projectName,
-      applicationReference,
-      type,
-      status,
-      submittedAt
-    } = exemption
+    const { _id, projectName, applicationReference, status, submittedAt } =
+      exemption
 
     return {
       id: _id.toString(),
-      type: type ?? EXEMPTION_TYPE.EXEMPT_ACTIVITY,
       ...(status && { status }),
       ...(projectName && { projectName }),
       ...(applicationReference && { applicationReference }),

--- a/src/api/exemptions/controllers/get-exemptions.test.js
+++ b/src/api/exemptions/controllers/get-exemptions.test.js
@@ -1,10 +1,7 @@
 import { jest } from '@jest/globals'
 import { getExemptionsController, sortByStatus } from './get-exemptions.js'
 import { ObjectId } from 'mongodb'
-import {
-  EXEMPTION_STATUS,
-  EXEMPTION_TYPE
-} from '../../../common/constants/exemption.js'
+import { EXEMPTION_STATUS } from '../../../common/constants/exemption.js'
 import { config } from '../../../config.js'
 
 jest.mock('../../../config.js')
@@ -88,13 +85,11 @@ describe('getExemptionsController', () => {
           {
             id: '507f1f77bcf86cd799439012',
             projectName: 'Test Project',
-            type: EXEMPTION_TYPE.EXEMPT_ACTIVITY,
             status: EXEMPTION_STATUS.DRAFT
           },
           {
             id: '507f1f77bcf86cd799439011',
             projectName: 'Other Project',
-            type: EXEMPTION_TYPE.EXEMPT_ACTIVITY,
             applicationReference: 'EXEMPTION-2024-001',
             status: EXEMPTION_STATUS.CLOSED,
             submittedAt: '2024-01-15T10:00:00.000Z'
@@ -102,7 +97,6 @@ describe('getExemptionsController', () => {
           {
             id: '507f1f77bcf86cd799439013',
             projectName: 'Beta Project',
-            type: EXEMPTION_TYPE.EXEMPT_ACTIVITY,
             status: 'Unknown status'
           }
         ]
@@ -137,8 +131,7 @@ describe('getExemptionsController', () => {
         message: 'success',
         value: [
           {
-            id: '507f1f77bcf86cd799439011',
-            type: EXEMPTION_TYPE.EXEMPT_ACTIVITY
+            id: '507f1f77bcf86cd799439011'
           }
         ]
       })

--- a/src/common/constants/exemption.js
+++ b/src/common/constants/exemption.js
@@ -5,5 +5,5 @@ export const EXEMPTION_STATUS = {
 }
 
 export const EXEMPTION_TYPE = {
-  EXEMPT_ACTIVITY: 'Exempt activity'
+  EXEMPT_ACTIVITY: 'EXEMPT_ACTIVITY'
 }

--- a/src/common/helpers/dynamics/dynamics-client.js
+++ b/src/common/helpers/dynamics/dynamics-client.js
@@ -1,7 +1,7 @@
 import Boom from '@hapi/boom'
 import Wreck from '@hapi/wreck'
 import { config } from '../../../config.js'
-import { EXEMPTION_STATUS } from '../../constants/exemption.js'
+import { EXEMPTION_STATUS, EXEMPTION_TYPE } from '../../constants/exemption.js'
 import querystring from 'node:querystring'
 import { StatusCodes } from 'http-status-codes'
 import { REQUEST_QUEUE_STATUS } from '../../constants/request-queue.js'
@@ -68,7 +68,7 @@ export const sendExemptionToDynamics = async (
     contactid: exemption.contactId,
     projectName: exemption.projectName,
     reference: applicationReferenceNumber,
-    type: exemption.type,
+    type: EXEMPTION_TYPE.EXEMPT_ACTIVITY,
     applicationUrl: `${frontEndBaseUrl}/exemption`,
     status: EXEMPTION_STATUS.SUBMITTED
   }

--- a/src/common/helpers/dynamics/dynamics-client.test.js
+++ b/src/common/helpers/dynamics/dynamics-client.test.js
@@ -99,8 +99,7 @@ describe('Dynamics Client', () => {
       _id: '123',
       contactId: 'test-contact-id',
       projectName: 'Test Project',
-      reference: 'TEST-REF-001',
-      type: 'Exempt activity'
+      reference: 'TEST-REF-001'
     }
 
     const mockAccessToken = 'test-access-token'
@@ -141,7 +140,7 @@ describe('Dynamics Client', () => {
             contactid: 'test-contact-id',
             projectName: 'Test Project',
             reference: 'TEST-REF-001',
-            type: 'Exempt activity',
+            type: 'EXEMPT_ACTIVITY',
             applicationUrl: 'http://localhost/exemption',
             status: EXEMPTION_STATUS.SUBMITTED
           },


### PR DESCRIPTION
The frontend will infer the label.
Use a constant to send a `type` property to D365 (which it won't use initially)