### PR TITLE
ML-638: Handle error in D365 Queue

### DIFF
--- a/src/api/exemptions/controllers/submit-exemption.js
+++ b/src/api/exemptions/controllers/submit-exemption.js
@@ -102,7 +102,11 @@ export const submitExemptionController = {
           updatedBy
         })
 
-        await request.server.methods.processExemptionsQueue()
+        request.server.methods.processExemptionsQueue().catch(() => {
+          request.server.logger.error(
+            'Failed to process exemptions queue, but exemption submission succeeded'
+          )
+        })
       }
 
       // async; don't wait for this to complete


### PR DESCRIPTION
Do not await the error, instead allow the handler to continue if there is an error.