### PR TITLE
DRAFT: ML-421: Provide activity description for manual entry sites

### DIFF
--- a/src/models/site-details/site-details.js
+++ b/src/models/site-details/site-details.js
@@ -40,18 +40,11 @@ export const siteDetailsSchema = joi
           then: activityDatesSchema,
           otherwise: joi.forbidden()
         }),
-        activityDescription: joi.when(
-          '/multipleSiteDetails.multipleSitesEnabled',
-          {
-            is: false,
-            then: joi.when('coordinatesType', {
-              is: 'coordinates',
-              then: activityDescriptionSchema,
-              otherwise: joi.forbidden()
-            }),
-            otherwise: joi.forbidden()
-          }
-        ),
+        activityDescription: joi.when('coordinatesType', {
+          is: 'coordinates',
+          then: activityDescriptionSchema,
+          otherwise: joi.forbidden()
+        }),
         siteName: joi.when('/multipleSiteDetails.multipleSitesEnabled', {
           is: true,
           then: joi.when('coordinatesType', {

--- a/src/models/site-details/site-details.test.js
+++ b/src/models/site-details/site-details.test.js
@@ -40,8 +40,7 @@ describe('#siteDetails schema', () => {
         const requestWithoutMultipleSiteDetails = {
           id: mockId,
           siteDetails: {
-            ...mockSiteDetails,
-            activityDescription: undefined
+            ...mockSiteDetails
           }
         }
         const result = siteDetailsSchema.validate(
@@ -134,6 +133,51 @@ describe('#siteDetails schema', () => {
       })
 
       test('Should allow file upload without activityDates', () => {
+        const result = siteDetailsSchema.validate(
+          mockFileUploadSiteDetailsRequest
+        )
+        expect(result.error).toBeUndefined()
+      })
+    })
+  })
+
+  describe('#activityDescription', () => {
+    describe('when coordinatesType is "coordinates"', () => {
+      test('Should fail when activityDescription is missing', () => {
+        const payload = {
+          ...mockSiteDetailsRequest,
+          siteDetails: {
+            ...mockSiteDetailsRequest.siteDetails,
+            activityDescription: undefined
+          }
+        }
+
+        const result = siteDetailsSchema.validate(payload)
+        expect(result.error.message).toContain('ACTIVITY_DESCRIPTION_REQUIRED')
+      })
+
+      test('Should not fail when activityDescription is defined', () => {
+        const result = siteDetailsSchema.validate(
+          mockSiteDetailsRequestWithMultiSite
+        )
+        expect(result.error).toBeUndefined()
+      })
+    })
+
+    describe('when coordinatesType is "file"', () => {
+      test('Should not allow activityDescription when coordinatesType is file', () => {
+        const result = siteDetailsSchema.validate({
+          ...mockFileUploadSiteDetailsRequest,
+          siteDetails: {
+            ...mockFileUploadSiteDetailsRequest.siteDetails,
+            activityDescription: 'Test'
+          }
+        })
+        expect(result.error.message).toContain('activityDescription')
+        expect(result.error.message).toContain('not allowed')
+      })
+
+      test('Should allow file upload without activityDescription', () => {
         const result = siteDetailsSchema.validate(
           mockFileUploadSiteDetailsRequest
         )

--- a/src/models/site-details/test-fixtures.js
+++ b/src/models/site-details/test-fixtures.js
@@ -35,8 +35,6 @@ export const mockSiteDetailsWithMultiSite = {
   siteName: 'Test Site Name'
 }
 
-delete mockSiteDetailsWithMultiSite.activityDescription
-
 export const mockSiteDetailsRequest = {
   id: mockId,
   multipleSiteDetails: mockMultipleSiteDetailsDisabled,


### PR DESCRIPTION
Provide activity description for manual entry sites on the multiple site journey. Activity Description is now required for all routes throught Manual Coordiantes.