### PR TITLE
ML-560 - Get exemption - don't authorize ownership if no auth token

### DIFF
--- a/src/api/exemptions/controllers/get-exemption.js
+++ b/src/api/exemptions/controllers/get-exemption.js
@@ -14,7 +14,7 @@ export const getExemptionController = {
   },
   handler: async (request, h) => {
     try {
-      const authStrategy = getJwtAuthStrategy(request.auth.artifacts.decoded)
+      const authStrategy = getJwtAuthStrategy(request.auth?.artifacts?.decoded)
       if (authStrategy === 'defraId') {
         await authorizeOwnership(request, h)
       }

--- a/src/plugins/auth.js
+++ b/src/plugins/auth.js
@@ -4,6 +4,9 @@ import { config } from '../config.js'
 import Boom from '@hapi/boom'
 
 export const getJwtAuthStrategy = (jwt) => {
+  if (!jwt) {
+    return null
+  }
   if (jwt.tid) {
     return 'entraId'
   }


### PR DESCRIPTION
if `authEnabled` is false, then request.auth won't be set; in this case, don't error, just return an exemption record