### PR TITLE
ML-1207 Sending to EMP fails for non-polygon uploads

### DIFF
--- a/src/shared/common/helpers/emp/transforms/file-upload.js
+++ b/src/shared/common/helpers/emp/transforms/file-upload.js
@@ -1,14 +1,59 @@
 import { geojsonToArcGIS } from '@terraformer/arcgis'
 import { SPATIAL_REFERENCES } from '../../../constants/coordinates.js'
 
+/**
+ * Tiny square (in degrees) around a lon/lat so polygon-based EMP layers accept
+ * GeoJSON Point / KML Point placemarks (ArcGIS REST uses x/y, not rings/paths).
+ * ~5 m at the equator.
+ */
+const POINT_RING_OFFSET_DEG = 0.00005
+
+function arcgisPointToRing(x, y) {
+  const d = POINT_RING_OFFSET_DEG
+  return [
+    [x - d, y - d],
+    [x + d, y - d],
+    [x + d, y + d],
+    [x - d, y + d],
+    [x - d, y - d]
+  ]
+}
+
+/**
+ * Normalises ArcGIS JSON geometries from geojsonToArcGIS into an array of
+ * coordinate rings/paths suitable for our EMP payload (grouped under `rings`).
+ */
+function coordSetsFromArcgisGeometry(geometry) {
+  if (!geometry) {
+    return []
+  }
+
+  const { rings, paths, points, x, y } = geometry
+
+  if (Array.isArray(rings) && rings.length > 0) {
+    return rings
+  }
+  if (Array.isArray(paths) && paths.length > 0) {
+    return paths
+  }
+  if (Number.isFinite(x) && Number.isFinite(y)) {
+    return [arcgisPointToRing(x, y)]
+  }
+  if (Array.isArray(points) && points.length > 0) {
+    return points.map(([px, py]) => arcgisPointToRing(px, py))
+  }
+
+  return []
+}
+
 export const fileUploadToEmpGeometry = (siteDetails) => {
   const features = siteDetails.reduce((acc, site) => {
     return [...acc, ...site.geoJSON.features]
   }, [])
   const transformed = geojsonToArcGIS({ type: 'FeatureCollection', features })
-  const geometries = transformed.reduce((acc, feature) => {
-    const coordSets = feature.geometry.rings || feature.geometry.paths
-    return [...acc, ...coordSets]
+  const geometries = transformed.reduce((acc, item) => {
+    const sets = coordSetsFromArcgisGeometry(item.geometry)
+    return [...acc, ...sets]
   }, [])
   return {
     rings: geometries,

--- a/src/shared/common/helpers/emp/transforms/file-upload.js
+++ b/src/shared/common/helpers/emp/transforms/file-upload.js
@@ -1,22 +1,20 @@
 import { geojsonToArcGIS } from '@terraformer/arcgis'
 import { SPATIAL_REFERENCES } from '../../../constants/coordinates.js'
+import { generateCirclePolygon } from './circle-to-polygon.js'
 
 /**
- * Tiny square (in degrees) around a lon/lat so polygon-based EMP layers accept
- * GeoJSON Point / KML Point placemarks (ArcGIS REST uses x/y, not rings/paths).
- * ~5 m at the equator.
+ * GeoJSON Point / KML placemarks become ArcGIS `{ x, y }` (no rings/paths).
+ * EMP expects polygon rings; approximate the point as a small geodesic circle
+ * so the map matches a point marker (not a square) and stays valid for polygon layers.
  */
-const POINT_RING_OFFSET_DEG = 0.00005
+const POINT_CIRCLE_RADIUS_METRES = 5
 
-function arcgisPointToRing(x, y) {
-  const d = POINT_RING_OFFSET_DEG
-  return [
-    [x - d, y - d],
-    [x + d, y - d],
-    [x + d, y + d],
-    [x - d, y + d],
-    [x - d, y - d]
-  ]
+function arcgisPointToPolygonRing(longitude, latitude) {
+  return generateCirclePolygon({
+    longitude,
+    latitude,
+    radiusMetres: POINT_CIRCLE_RADIUS_METRES
+  })
 }
 
 /**
@@ -37,10 +35,10 @@ function coordSetsFromArcgisGeometry(geometry) {
     return paths
   }
   if (Number.isFinite(x) && Number.isFinite(y)) {
-    return [arcgisPointToRing(x, y)]
+    return [arcgisPointToPolygonRing(x, y)]
   }
   if (Array.isArray(points) && points.length > 0) {
-    return points.map(([px, py]) => arcgisPointToRing(px, py))
+    return points.map(([px, py]) => arcgisPointToPolygonRing(px, py))
   }
 
   return []

--- a/src/shared/common/helpers/emp/transforms/file-upload.test.js
+++ b/src/shared/common/helpers/emp/transforms/file-upload.test.js
@@ -1,5 +1,20 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import * as TerraformerArcgis from '@terraformer/arcgis'
 import { fileUploadToEmpGeometry } from './file-upload.js'
+
+const dummySiteDetails = [
+  {
+    geoJSON: {
+      type: 'FeatureCollection',
+      features: [
+        {
+          type: 'Feature',
+          geometry: { type: 'Point', coordinates: [0, 0] }
+        }
+      ]
+    }
+  }
+]
 
 describe('fileUploadToEmpGeometry', () => {
   it('transforms single site with geoJSON features to EMP geometry format', () => {
@@ -357,5 +372,54 @@ describe('fileUploadToEmpGeometry', () => {
       [3, 3]
     ])
     expect(result.spatialReference).toEqual({ wkid: 4326 })
+  })
+})
+
+describe('fileUploadToEmpGeometry when ArcGIS conversion returns edge cases', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('omits rings when geojsonToArcGIS yields null geometry', () => {
+    vi.spyOn(TerraformerArcgis, 'geojsonToArcGIS').mockReturnValue([
+      { geometry: null }
+    ])
+
+    const result = fileUploadToEmpGeometry(dummySiteDetails)
+
+    expect(result.rings).toEqual([])
+    expect(result.spatialReference).toEqual({ wkid: 4326 })
+  })
+
+  it('omits rings when geometry has empty rings and paths only', () => {
+    vi.spyOn(TerraformerArcgis, 'geojsonToArcGIS').mockReturnValue([
+      {
+        geometry: {
+          rings: [],
+          paths: [],
+          spatialReference: { wkid: 4326 }
+        }
+      }
+    ])
+
+    const result = fileUploadToEmpGeometry(dummySiteDetails)
+
+    expect(result.rings).toEqual([])
+  })
+
+  it('omits rings when point has non-finite coordinates', () => {
+    vi.spyOn(TerraformerArcgis, 'geojsonToArcGIS').mockReturnValue([
+      {
+        geometry: {
+          x: Number.NaN,
+          y: 50,
+          spatialReference: { wkid: 4326 }
+        }
+      }
+    ])
+
+    const result = fileUploadToEmpGeometry(dummySiteDetails)
+
+    expect(result.rings).toEqual([])
   })
 })

--- a/src/shared/common/helpers/emp/transforms/file-upload.test.js
+++ b/src/shared/common/helpers/emp/transforms/file-upload.test.js
@@ -2,6 +2,24 @@ import { describe, it, expect, vi, afterEach } from 'vitest'
 import * as TerraformerArcgis from '@terraformer/arcgis'
 import { fileUploadToEmpGeometry } from './file-upload.js'
 
+/** Arithmetic mean of ring vertices (rough centroid for symmetric rings). */
+function meanVertexCoords(ring) {
+  let sumX = 0
+  let sumY = 0
+  for (const p of ring) {
+    sumX += p[0]
+    sumY += p[1]
+  }
+  const n = ring.length
+  return [sumX / n, sumY / n]
+}
+
+function expectRingMeanCloseTo(ring, expectedX, expectedY, numDigits = 2) {
+  const [mx, my] = meanVertexCoords(ring)
+  expect(mx).toBeCloseTo(expectedX, numDigits)
+  expect(my).toBeCloseTo(expectedY, numDigits)
+}
+
 const dummySiteDetails = [
   {
     geoJSON: {
@@ -173,10 +191,7 @@ describe('fileUploadToEmpGeometry', () => {
     expect(ring[0][0]).toBeCloseTo(ring.at(-1)[0], 5)
     expect(ring[0][1]).toBeCloseTo(ring.at(-1)[1], 5)
 
-    const cx = ring.reduce((s, p) => s + p[0], 0) / ring.length
-    const cy = ring.reduce((s, p) => s + p[1], 0) / ring.length
-    expect(cx).toBeCloseTo(-4.1525, 2)
-    expect(cy).toBeCloseTo(50.3475, 2)
+    expectRingMeanCloseTo(ring, -4.1525, 50.3475)
 
     expect(result.spatialReference).toEqual({ wkid: 4326 })
   })
@@ -211,19 +226,8 @@ describe('fileUploadToEmpGeometry', () => {
       expect(ring[0][1]).toBeCloseTo(ring.at(-1)[1], 5)
     }
 
-    const c0x =
-      result.rings[0].reduce((s, p) => s + p[0], 0) / result.rings[0].length
-    const c0y =
-      result.rings[0].reduce((s, p) => s + p[1], 0) / result.rings[0].length
-    expect(c0x).toBeCloseTo(-4.0, 2)
-    expect(c0y).toBeCloseTo(50.0, 2)
-
-    const c1x =
-      result.rings[1].reduce((s, p) => s + p[0], 0) / result.rings[1].length
-    const c1y =
-      result.rings[1].reduce((s, p) => s + p[1], 0) / result.rings[1].length
-    expect(c1x).toBeCloseTo(-5.0, 2)
-    expect(c1y).toBeCloseTo(51.0, 2)
+    expectRingMeanCloseTo(result.rings[0], -4.0, 50.0)
+    expectRingMeanCloseTo(result.rings[1], -5.0, 51.0)
 
     expect(result.spatialReference).toEqual({ wkid: 4326 })
   })

--- a/src/shared/common/helpers/emp/transforms/file-upload.test.js
+++ b/src/shared/common/helpers/emp/transforms/file-upload.test.js
@@ -132,6 +132,68 @@ describe('fileUploadToEmpGeometry', () => {
     expect(result.spatialReference).toEqual({ wkid: 4326 })
   })
 
+  it('handles Point geometry (e.g. KML Placemark with Point)', () => {
+    const siteDetails = [
+      {
+        geoJSON: {
+          type: 'FeatureCollection',
+          features: [
+            {
+              type: 'Feature',
+              geometry: {
+                type: 'Point',
+                coordinates: [-4.1525, 50.3475]
+              }
+            }
+          ]
+        }
+      }
+    ]
+
+    const result = fileUploadToEmpGeometry(siteDetails)
+
+    const d = 0.00005
+    expect(result.rings).toHaveLength(1)
+    expect(result.rings[0]).toEqual([
+      [-4.1525 - d, 50.3475 - d],
+      [-4.1525 + d, 50.3475 - d],
+      [-4.1525 + d, 50.3475 + d],
+      [-4.1525 - d, 50.3475 + d],
+      [-4.1525 - d, 50.3475 - d]
+    ])
+    expect(result.spatialReference).toEqual({ wkid: 4326 })
+  })
+
+  it('handles MultiPoint as separate small rings', () => {
+    const siteDetails = [
+      {
+        geoJSON: {
+          type: 'FeatureCollection',
+          features: [
+            {
+              type: 'Feature',
+              geometry: {
+                type: 'MultiPoint',
+                coordinates: [
+                  [-4.0, 50.0],
+                  [-5.0, 51.0]
+                ]
+              }
+            }
+          ]
+        }
+      }
+    ]
+
+    const result = fileUploadToEmpGeometry(siteDetails)
+    const d = 0.00005
+
+    expect(result.rings).toHaveLength(2)
+    expect(result.rings[0][0]).toEqual([-4.0 - d, 50.0 - d])
+    expect(result.rings[1][0]).toEqual([-5.0 - d, 51.0 - d])
+    expect(result.spatialReference).toEqual({ wkid: 4326 })
+  })
+
   it('handles features with paths instead of rings (LineString geometries)', () => {
     const siteDetails = [
       {

--- a/src/shared/common/helpers/emp/transforms/file-upload.test.js
+++ b/src/shared/common/helpers/emp/transforms/file-upload.test.js
@@ -132,7 +132,7 @@ describe('fileUploadToEmpGeometry', () => {
     expect(result.spatialReference).toEqual({ wkid: 4326 })
   })
 
-  it('handles Point geometry (e.g. KML Placemark with Point)', () => {
+  it('handles Point geometry (e.g. KML Placemark with Point) as a geodesic circle', () => {
     const siteDetails = [
       {
         geoJSON: {
@@ -152,19 +152,21 @@ describe('fileUploadToEmpGeometry', () => {
 
     const result = fileUploadToEmpGeometry(siteDetails)
 
-    const d = 0.00005
     expect(result.rings).toHaveLength(1)
-    expect(result.rings[0]).toEqual([
-      [-4.1525 - d, 50.3475 - d],
-      [-4.1525 + d, 50.3475 - d],
-      [-4.1525 + d, 50.3475 + d],
-      [-4.1525 - d, 50.3475 + d],
-      [-4.1525 - d, 50.3475 - d]
-    ])
+    const ring = result.rings[0]
+    expect(ring.length).toBeGreaterThan(8)
+    expect(ring[0][0]).toBeCloseTo(ring.at(-1)[0], 5)
+    expect(ring[0][1]).toBeCloseTo(ring.at(-1)[1], 5)
+
+    const cx = ring.reduce((s, p) => s + p[0], 0) / ring.length
+    const cy = ring.reduce((s, p) => s + p[1], 0) / ring.length
+    expect(cx).toBeCloseTo(-4.1525, 2)
+    expect(cy).toBeCloseTo(50.3475, 2)
+
     expect(result.spatialReference).toEqual({ wkid: 4326 })
   })
 
-  it('handles MultiPoint as separate small rings', () => {
+  it('handles MultiPoint as separate geodesic circle rings', () => {
     const siteDetails = [
       {
         geoJSON: {
@@ -186,11 +188,28 @@ describe('fileUploadToEmpGeometry', () => {
     ]
 
     const result = fileUploadToEmpGeometry(siteDetails)
-    const d = 0.00005
 
     expect(result.rings).toHaveLength(2)
-    expect(result.rings[0][0]).toEqual([-4.0 - d, 50.0 - d])
-    expect(result.rings[1][0]).toEqual([-5.0 - d, 51.0 - d])
+    for (const ring of result.rings) {
+      expect(ring.length).toBeGreaterThan(8)
+      expect(ring[0][0]).toBeCloseTo(ring.at(-1)[0], 5)
+      expect(ring[0][1]).toBeCloseTo(ring.at(-1)[1], 5)
+    }
+
+    const c0x =
+      result.rings[0].reduce((s, p) => s + p[0], 0) / result.rings[0].length
+    const c0y =
+      result.rings[0].reduce((s, p) => s + p[1], 0) / result.rings[0].length
+    expect(c0x).toBeCloseTo(-4.0, 2)
+    expect(c0y).toBeCloseTo(50.0, 2)
+
+    const c1x =
+      result.rings[1].reduce((s, p) => s + p[0], 0) / result.rings[1].length
+    const c1y =
+      result.rings[1].reduce((s, p) => s + p[1], 0) / result.rings[1].length
+    expect(c1x).toBeCloseTo(-5.0, 2)
+    expect(c1y).toBeCloseTo(51.0, 2)
+
     expect(result.spatialReference).toEqual({ wkid: 4326 })
   })
 


### PR DESCRIPTION
**Summary**
Fixes EMP / ArcGIS addFeatures when site geometry comes from file uploads (e.g. KML) that contain GeoJSON Point or MultiPoint. Those cases were not handled after geojsonToArcGIS, which led to coordSets is not iterable and failed queue processing.

**Problem**
fileUploadToEmpGeometry only spread rings or paths. ArcGIS JSON for a Point is { x, y, spatialReference }, so the spread target was undefined and the processor threw before calling ArcGIS.

**Solution**
coordSetsFromArcGISGeometry normalises ArcGIS output from @terraformer/arcgis:
existing rings / paths behaviour unchanged (polygons, lines);
Point (x, y) and MultiPoint (points) are turned into polygon rings in the shape EMP already expects.
Because the layer expects polygon geometry, points are represented as a small geodesic circle using the same generateCirclePolygon helper as manual circle sites (5 m radius), so the map shows a circle, not a square placeholder.