### PR TITLE
ML-1256 Reference generation: retry when mongo-locks acquisition fails (on load)

### DIFF
--- a/src/exemptions/api/controllers/submit-exemption.integration.test.js
+++ b/src/exemptions/api/controllers/submit-exemption.integration.test.js
@@ -170,4 +170,61 @@ describe('POST /exemption/submit', async () => {
       'South East offshore'
     ])
   })
+
+  it('assigns unique references when many exemptions submit in parallel (reference lock contention)', async () => {
+    const parallelCount = 8
+    const year = mockDate.getFullYear()
+    const sequenceKey = `EXEMPTION_${year}`
+
+    await db.collection(collectionExemptions).deleteMany({
+      contactId: mockCredentials.contactId
+    })
+    await db.collection('reference-sequences').deleteMany({ key: sequenceKey })
+
+    const ids = []
+    for (let i = 0; i < parallelCount; i++) {
+      const id = new ObjectId()
+      ids.push(id)
+      await db.collection(collectionExemptions).insertOne(
+        createCompleteExemption({
+          _id: id,
+          contactId: mockCredentials.contactId
+        })
+      )
+    }
+
+    const server = getServer()
+    const responses = await Promise.all(
+      ids.map((id) =>
+        server.inject({
+          method: 'POST',
+          url: '/exemption/submit',
+          payload: {
+            id: id.toHexString(),
+            userEmail: 'parallel@example.com',
+            userName: 'Parallel User'
+          },
+          auth: {
+            strategy: 'jwt',
+            credentials: mockCredentials
+          }
+        })
+      )
+    )
+
+    for (const res of responses) {
+      expect(res.statusCode).toBe(200)
+    }
+
+    const refs = responses.map(
+      (r) => JSON.parse(r.payload).value.applicationReference
+    )
+    expect(new Set(refs).size).toBe(parallelCount)
+
+    const nums = refs.map((ref) => Number.parseInt(ref.split('/')[2], 10))
+    nums.sort((a, b) => a - b)
+    for (let i = 0; i < parallelCount; i++) {
+      expect(nums[i]).toBe(10001 + i)
+    }
+  }, 30_000)
 })

--- a/src/exemptions/api/controllers/submit-exemption.integration.test.js
+++ b/src/exemptions/api/controllers/submit-exemption.integration.test.js
@@ -181,26 +181,26 @@ describe('POST /exemption/submit', async () => {
     })
     await db.collection('reference-sequences').deleteMany({ key: sequenceKey })
 
-    const ids = []
+    const draftExemptionIds = []
     for (let i = 0; i < parallelCount; i++) {
-      const id = new ObjectId()
-      ids.push(id)
+      const draftExemptionId = new ObjectId()
+      draftExemptionIds.push(draftExemptionId)
       await db.collection(collectionExemptions).insertOne(
         createCompleteExemption({
-          _id: id,
+          _id: draftExemptionId,
           contactId: mockCredentials.contactId
         })
       )
     }
 
     const server = getServer()
-    const responses = await Promise.all(
-      ids.map((id) =>
+    const submitResponses = await Promise.all(
+      draftExemptionIds.map((draftExemptionId) =>
         server.inject({
           method: 'POST',
           url: '/exemption/submit',
           payload: {
-            id: id.toHexString(),
+            id: draftExemptionId.toHexString(),
             userEmail: 'parallel@example.com',
             userName: 'Parallel User'
           },
@@ -212,19 +212,31 @@ describe('POST /exemption/submit', async () => {
       )
     )
 
-    for (const res of responses) {
-      expect(res.statusCode).toBe(200)
+    for (const response of submitResponses) {
+      expect(response.statusCode).toBe(200)
     }
 
-    const refs = responses.map(
-      (r) => JSON.parse(r.payload).value.applicationReference
-    )
-    expect(new Set(refs).size).toBe(parallelCount)
+    const applicationReferences = submitResponses.map((response) => {
+      const body = JSON.parse(response.payload)
+      return body.value.applicationReference
+    })
+    // Parallel submits must not reuse the same reference. A Set drops duplicates, so its size stays parallelCount only when every reference is distinct.
+    expect(new Set(applicationReferences).size).toBe(parallelCount)
 
-    const nums = refs.map((ref) => Number.parseInt(ref.split('/')[2], 10))
-    nums.sort((a, b) => a - b)
+    // Distinct references alone do not prove the DB sequence advanced correctly (e.g. gaps or wrong start).
+    // References look like EXE/{year}/{sequence}. Parse the numeric segment, sort, then each expect() checks
+    // we received the next contiguous values starting at expectedFirstSequenceNumber (through 10001 + parallelCount - 1).
+    const sequenceSegmentIndex = 2
+    const expectedFirstSequenceNumber = 10001
+    const sequenceNumbersAscending = applicationReferences
+      .map((reference) => {
+        const segments = reference.split('/')
+        const sequenceSegment = segments[sequenceSegmentIndex]
+        return Number.parseInt(sequenceSegment, 10)
+      })
+      .sort((a, b) => a - b)
     for (let i = 0; i < parallelCount; i++) {
-      expect(nums[i]).toBe(10001 + i)
+      expect(sequenceNumbersAscending[i]).toBe(expectedFirstSequenceNumber + i)
     }
   }, 30_000)
 })

--- a/src/exemptions/api/controllers/submit-exemption.test.js
+++ b/src/exemptions/api/controllers/submit-exemption.test.js
@@ -691,9 +691,11 @@ describe('POST /exemption/submit', () => {
       }
 
       mockExemptionsCollection.findOne.mockResolvedValue(mockExemption)
-      generateApplicationReference.mockRejectedValue(
-        Boom.internal('Unable to acquire lock for reference generation')
+      const lockError = Boom.serverUnavailable(
+        'Unable to acquire lock for reference generation'
       )
+      lockError.output.headers['Retry-After'] = 2
+      generateApplicationReference.mockRejectedValue(lockError)
 
       await expect(
         submitExemptionController.handler(

--- a/src/marine-licences/api/controllers/submit-marine-licence.integration.test.js
+++ b/src/marine-licences/api/controllers/submit-marine-licence.integration.test.js
@@ -137,26 +137,26 @@ describe('POST /marine-licence/submit', async () => {
     })
     await db.collection('reference-sequences').deleteMany({ key: sequenceKey })
 
-    const ids = []
+    const draftMarineLicenceIds = []
     for (let i = 0; i < parallelCount; i++) {
-      const id = new ObjectId()
-      ids.push(id)
+      const draftMarineLicenceId = new ObjectId()
+      draftMarineLicenceIds.push(draftMarineLicenceId)
       await db.collection(collectionMarineLicences).insertOne(
         createCompleteMarineLicence({
-          _id: id,
+          _id: draftMarineLicenceId,
           contactId: mockCredentials.contactId
         })
       )
     }
 
     const server = getServer()
-    const responses = await Promise.all(
-      ids.map((id) =>
+    const submitResponses = await Promise.all(
+      draftMarineLicenceIds.map((draftMarineLicenceId) =>
         server.inject({
           method: 'POST',
           url: '/marine-licence/submit',
           payload: {
-            id: id.toHexString(),
+            id: draftMarineLicenceId.toHexString(),
             userEmail: 'parallel@example.com',
             userName: 'Parallel User'
           },
@@ -168,19 +168,31 @@ describe('POST /marine-licence/submit', async () => {
       )
     )
 
-    for (const res of responses) {
-      expect(res.statusCode).toBe(200)
+    for (const response of submitResponses) {
+      expect(response.statusCode).toBe(200)
     }
 
-    const refs = responses.map(
-      (r) => JSON.parse(r.payload).value.applicationReference
-    )
-    expect(new Set(refs).size).toBe(parallelCount)
+    const applicationReferences = submitResponses.map((response) => {
+      const body = JSON.parse(response.payload)
+      return body.value.applicationReference
+    })
+    // Parallel submits must not reuse the same reference. A Set drops duplicates, so its size stays parallelCount only when every reference is distinct.
+    expect(new Set(applicationReferences).size).toBe(parallelCount)
 
-    const nums = refs.map((ref) => Number.parseInt(ref.split('/')[2], 10))
-    nums.sort((a, b) => a - b)
+    // Distinct references alone do not prove the DB sequence advanced correctly (e.g. gaps or wrong start).
+    // References look like MLA/{year}/{sequence}. Parse the numeric segment, sort, then each expect() checks
+    // we received the next contiguous values starting at expectedFirstSequenceNumber (through 10001 + parallelCount - 1).
+    const sequenceSegmentIndex = 2
+    const expectedFirstSequenceNumber = 10001
+    const sequenceNumbersAscending = applicationReferences
+      .map((reference) => {
+        const segments = reference.split('/')
+        const sequenceSegment = segments[sequenceSegmentIndex]
+        return Number.parseInt(sequenceSegment, 10)
+      })
+      .sort((a, b) => a - b)
     for (let i = 0; i < parallelCount; i++) {
-      expect(nums[i]).toBe(10001 + i)
+      expect(sequenceNumbersAscending[i]).toBe(expectedFirstSequenceNumber + i)
     }
   }, 30_000)
 })

--- a/src/marine-licences/api/controllers/submit-marine-licence.integration.test.js
+++ b/src/marine-licences/api/controllers/submit-marine-licence.integration.test.js
@@ -126,4 +126,61 @@ describe('POST /marine-licence/submit', async () => {
 
     expect(response.statusCode).toBe(409)
   })
+
+  it('assigns unique references when many marine licences submit in parallel (reference lock contention)', async () => {
+    const parallelCount = 8
+    const year = mockDate.getFullYear()
+    const sequenceKey = `MARINE_LICENCE_${year}`
+
+    await db.collection(collectionMarineLicences).deleteMany({
+      contactId: mockCredentials.contactId
+    })
+    await db.collection('reference-sequences').deleteMany({ key: sequenceKey })
+
+    const ids = []
+    for (let i = 0; i < parallelCount; i++) {
+      const id = new ObjectId()
+      ids.push(id)
+      await db.collection(collectionMarineLicences).insertOne(
+        createCompleteMarineLicence({
+          _id: id,
+          contactId: mockCredentials.contactId
+        })
+      )
+    }
+
+    const server = getServer()
+    const responses = await Promise.all(
+      ids.map((id) =>
+        server.inject({
+          method: 'POST',
+          url: '/marine-licence/submit',
+          payload: {
+            id: id.toHexString(),
+            userEmail: 'parallel@example.com',
+            userName: 'Parallel User'
+          },
+          auth: {
+            strategy: 'jwt',
+            credentials: mockCredentials
+          }
+        })
+      )
+    )
+
+    for (const res of responses) {
+      expect(res.statusCode).toBe(200)
+    }
+
+    const refs = responses.map(
+      (r) => JSON.parse(r.payload).value.applicationReference
+    )
+    expect(new Set(refs).size).toBe(parallelCount)
+
+    const nums = refs.map((ref) => Number.parseInt(ref.split('/')[2], 10))
+    nums.sort((a, b) => a - b)
+    for (let i = 0; i < parallelCount; i++) {
+      expect(nums[i]).toBe(10001 + i)
+    }
+  }, 30_000)
 })

--- a/src/marine-licences/api/controllers/submit-marine-licence.test.js
+++ b/src/marine-licences/api/controllers/submit-marine-licence.test.js
@@ -483,9 +483,11 @@ describe('POST /marine-licence/submit', () => {
       }
 
       mockMarineLicencesCollection.findOne.mockResolvedValue(mockMarineLicence)
-      generateApplicationReference.mockRejectedValue(
-        Boom.internal('Unable to acquire lock for reference generation')
+      const lockError = Boom.serverUnavailable(
+        'Unable to acquire lock for reference generation'
       )
+      lockError.output.headers['Retry-After'] = 2
+      generateApplicationReference.mockRejectedValue(lockError)
 
       await expect(
         submitMarineLicenceController.handler(

--- a/src/shared/helpers/reference-generator.js
+++ b/src/shared/helpers/reference-generator.js
@@ -8,13 +8,81 @@ const APPLICATION_TYPES = {
 const SEQUENCE_SEED = 10001
 const SEQUENCE_DIGITS = 5
 
+const LOCK_EXHAUSTED_MESSAGE = 'Unable to acquire lock for reference generation'
+
+/**
+ * mongo-locks uses insert + unique index: concurrent callers get lock === null
+ * immediately (no queue). Multiple backend replicas and parallel submits for the
+ * same year contend on one key (reference-generation-{sequenceKey}); bounded retry
+ * absorbs short-lived contention without manual resubmit.
+ */
+export const REFERENCE_LOCK_RETRY_DEFAULTS = Object.freeze({
+  /** Upper bound on lock acquisition attempts */
+  maxAttempts: 12,
+  /** First backoff delay (ms); doubles each retry until maxBackoffMs */
+  initialBackoffMs: 35,
+  /** Ceiling for a single wait between retries (ms) */
+  maxBackoffMs: 200
+})
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+function delayMsForAttempt(attemptIndex, { initialBackoffMs, maxBackoffMs }) {
+  return Math.min(initialBackoffMs * 2 ** attemptIndex, maxBackoffMs)
+}
+
+function mergeLockRetryOptions(lockRetryOptions) {
+  return { ...REFERENCE_LOCK_RETRY_DEFAULTS, ...lockRetryOptions }
+}
+
+/** Total time spent sleeping between attempts (for Retry-After hint). */
+export function totalReferenceLockRetryWaitMs(
+  lockRetryOptions = REFERENCE_LOCK_RETRY_DEFAULTS
+) {
+  const merged = mergeLockRetryOptions(lockRetryOptions)
+  const delayCount = Math.max(0, merged.maxAttempts - 1)
+  return Array.from({ length: delayCount }, (_, attempt) =>
+    delayMsForAttempt(attempt, merged)
+  ).reduce((sum, ms) => sum + ms, 0)
+}
+
+async function acquireReferenceGenerationLock(
+  locker,
+  resource,
+  lockRetryOptions
+) {
+  const opts = mergeLockRetryOptions(lockRetryOptions)
+
+  const walk = async (attempt) => {
+    const lock = await locker.lock(resource)
+    if (lock) {
+      return lock
+    }
+    if (attempt >= opts.maxAttempts - 1) {
+      return null
+    }
+    await sleep(delayMsForAttempt(attempt, opts))
+    return walk(attempt + 1)
+  }
+
+  return walk(0)
+}
+
 /**
  * Generates a unique application reference in the format: PREFIX/YYYY/NNNNN
+ *
+ * @param {import('mongodb').Db} db
+ * @param {{ lock: (key: string) => Promise<unknown> }} locker
+ * @param {'EXEMPTION'|'MARINE_LICENCE'} [applicationType]
+ * @param {Partial<typeof REFERENCE_LOCK_RETRY_DEFAULTS>} [lockRetryOptions] — override for tests or tuning
  */
 export async function generateApplicationReference(
   db,
   locker,
-  applicationType = 'EXEMPTION'
+  applicationType = 'EXEMPTION',
+  lockRetryOptions = undefined
 ) {
   const prefix = APPLICATION_TYPES[applicationType]
   if (!prefix) {
@@ -25,10 +93,17 @@ export async function generateApplicationReference(
   const currentYear = now.getFullYear()
   const sequenceKey = `${applicationType}_${currentYear}`
 
-  const lock = await locker.lock(`reference-generation-${sequenceKey}`)
+  const lock = await acquireReferenceGenerationLock(
+    locker,
+    `reference-generation-${sequenceKey}`,
+    lockRetryOptions
+  )
 
   if (!lock) {
-    throw Boom.internal('Unable to acquire lock for reference generation')
+    const budgetMs = totalReferenceLockRetryWaitMs(lockRetryOptions)
+    const err = Boom.serverUnavailable(LOCK_EXHAUSTED_MESSAGE)
+    err.output.headers['Retry-After'] = Math.max(1, Math.ceil(budgetMs / 1000))
+    throw err
   }
 
   try {

--- a/src/shared/helpers/reference-generator.test.js
+++ b/src/shared/helpers/reference-generator.test.js
@@ -1,5 +1,9 @@
 import { vi } from 'vitest'
-import { generateApplicationReference } from './reference-generator.js'
+import {
+  generateApplicationReference,
+  REFERENCE_LOCK_RETRY_DEFAULTS,
+  totalReferenceLockRetryWaitMs
+} from './reference-generator.js'
 import Boom from '@hapi/boom'
 
 describe('generateApplicationReference', () => {
@@ -234,16 +238,116 @@ describe('generateApplicationReference', () => {
       expect(mockLock.free).toHaveBeenCalled()
     })
 
-    it('should throw error if unable to acquire lock', async () => {
-      mockLocker.lock.mockResolvedValue(null)
+    it('should return 503 with Retry-After after exhausting lock retries', async () => {
+      vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] })
+      const fastRetry = {
+        maxAttempts: 5,
+        initialBackoffMs: 10,
+        maxBackoffMs: 40
+      }
+      try {
+        mockLocker.lock.mockResolvedValue(null)
 
-      await expect(
-        generateApplicationReference(mockDb, mockLocker, 'EXEMPTION')
-      ).rejects.toThrow(
-        Boom.internal('Unable to acquire lock for reference generation')
+        const promise = expect(
+          generateApplicationReference(
+            mockDb,
+            mockLocker,
+            'EXEMPTION',
+            fastRetry
+          )
+        ).rejects.toMatchObject({
+          message: 'Unable to acquire lock for reference generation',
+          output: {
+            statusCode: 503,
+            headers: { 'Retry-After': expect.any(Number) }
+          }
+        })
+
+        await vi.advanceTimersByTimeAsync(
+          totalReferenceLockRetryWaitMs(fastRetry) + 50
+        )
+        await promise
+
+        expect(mockDb.collection().findOneAndUpdate).not.toHaveBeenCalled()
+        expect(mockLocker.lock).toHaveBeenCalledTimes(fastRetry.maxAttempts)
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+
+    it('should succeed on the second lock attempt after one contention', async () => {
+      vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] })
+      try {
+        const mockSequenceDoc = { currentSequence: 10001 }
+        mockDb.collection().findOneAndUpdate.mockResolvedValue(mockSequenceDoc)
+        mockDb.collection().updateOne.mockResolvedValue({ acknowledged: true })
+
+        mockLocker.lock.mockResolvedValueOnce(null).mockResolvedValue(mockLock)
+
+        const retryOpts = {
+          maxAttempts: 8,
+          initialBackoffMs: 10,
+          maxBackoffMs: 10
+        }
+        const resultPromise = generateApplicationReference(
+          mockDb,
+          mockLocker,
+          'EXEMPTION',
+          retryOpts
+        )
+        await vi.advanceTimersByTimeAsync(retryOpts.initialBackoffMs + 5)
+        const result = await resultPromise
+
+        expect(result).toBe('EXE/2025/10001')
+        expect(mockLocker.lock).toHaveBeenCalledTimes(2)
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+
+    it('should succeed after many null lock responses then an acquired lock', async () => {
+      vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] })
+      try {
+        const mockSequenceDoc = { currentSequence: 10001 }
+        mockDb.collection().findOneAndUpdate.mockResolvedValue(mockSequenceDoc)
+        mockDb.collection().updateOne.mockResolvedValue({ acknowledged: true })
+
+        const retryOpts = {
+          maxAttempts: 12,
+          initialBackoffMs: 5,
+          maxBackoffMs: 5
+        }
+        let call = 0
+        mockLocker.lock.mockImplementation(async () => {
+          call++
+          return call < 8 ? null : mockLock
+        })
+
+        const resultPromise = generateApplicationReference(
+          mockDb,
+          mockLocker,
+          'EXEMPTION',
+          retryOpts
+        )
+        await vi.advanceTimersByTimeAsync(
+          totalReferenceLockRetryWaitMs(retryOpts) + 20
+        )
+        const result = await resultPromise
+
+        expect(result).toBe('EXE/2025/10001')
+        expect(mockLocker.lock).toHaveBeenCalledTimes(8)
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+
+    it('should use default retry budget within roughly 1-2s', () => {
+      const totalMs = totalReferenceLockRetryWaitMs()
+      expect(totalMs).toBeGreaterThan(900)
+      expect(totalMs).toBeLessThanOrEqual(2100)
+      expect(REFERENCE_LOCK_RETRY_DEFAULTS.maxAttempts).toBeGreaterThanOrEqual(
+        8
       )
-
-      expect(mockDb.collection().findOneAndUpdate).not.toHaveBeenCalled()
     })
   })
 


### PR DESCRIPTION
**fix**: retry reference-generation locks and return 503 when exhausted

Adds bounded exponential backoff when acquiring the mongo-locks key for reference generation (reference-generation-{year}), so short contention from multiple replicas or parallel submits no longer fails on the first lock === null. After retries are exhausted, the API returns 503 Service Unavailable with Retry-After instead of an immediate 500. Includes unit tests (success after retries, exhaustion path, defaults) and small refactor of the lock loop for clarity.