### PR TITLE
ML-1290 move geo lookups and queue inserts to background on exemption submit

### DIFF
--- a/src/exemptions/api/controllers/submit-exemption.integration.test.js
+++ b/src/exemptions/api/controllers/submit-exemption.integration.test.js
@@ -71,7 +71,14 @@ describe('POST /exemption/submit', async () => {
       mockApplicationReference
     )
     expect(updatedExemption.submittedAt).toEqual(mockDate)
-    expect(updatedExemption.marinePlanAreas).toEqual([])
+
+    // marinePlanAreas is written in the background after the response
+    await vi.waitFor(async () => {
+      const ex = await db
+        .collection(collectionExemptions)
+        .findOne({ _id: exemptionId })
+      expect(ex.marinePlanAreas).toEqual([])
+    })
   })
 
   it('should return 404 if not found in database', async () => {
@@ -165,10 +172,17 @@ describe('POST /exemption/submit', async () => {
       mockApplicationReference
     )
     expect(updatedExemption.submittedAt).toEqual(mockDate)
-    expect(updatedExemption.marinePlanAreas).toEqual([
-      'South East Inshore',
-      'South East offshore'
-    ])
+
+    // marinePlanAreas is written in the background after the response
+    await vi.waitFor(async () => {
+      const ex = await db
+        .collection(collectionExemptions)
+        .findOne({ _id: exemptionId })
+      expect(ex.marinePlanAreas).toEqual([
+        'South East Inshore',
+        'South East offshore'
+      ])
+    })
   })
 
   it('assigns unique references when many exemptions submit in parallel (reference lock contention)', async () => {

--- a/src/exemptions/api/controllers/submit-exemption.js
+++ b/src/exemptions/api/controllers/submit-exemption.js
@@ -15,6 +15,7 @@ import { addToDynamicsQueue } from '../../../shared/common/helpers/dynamics/inde
 import { addToEmpQueue } from '../../../shared/common/helpers/emp/index.js'
 import { updateMarinePlanningAreas } from '../../../shared/common/helpers/geo/update-marine-planning-areas.js'
 import { updateCoastalOperationsAreas } from '../../../shared/common/helpers/geo/update-coastal-operations-areas.js'
+import { structureErrorForECS } from '../../../shared/common/helpers/logging/logger.js'
 import {
   DYNAMICS_REQUEST_ACTIONS,
   EMP_REQUEST_ACTIONS
@@ -126,11 +127,28 @@ export const submitExemptionController = {
 
       // Run geo lookups, queue inserts and email in the background so the
       // user receives applicationReference and submittedAt immediately.
-      // Geo writes must finish before the queue inserts because Dynamics/EMP
-      // read marinePlanAreas and coastalOperationsAreas off the exemption doc.
+      // Each geo operation catches its own errors so a failure in one does
+      // not block the other or the Dynamics/EMP queue inserts — geo areas
+      // can be backfilled independently via the backfill-areas endpoint.
       Promise.all([
-        updateCoastalOperationsAreas(exemption, db, { updatedAt, updatedBy }),
-        updateMarinePlanningAreas(exemption, db, { updatedAt, updatedBy })
+        updateCoastalOperationsAreas(exemption, db, {
+          updatedAt,
+          updatedBy
+        }).catch((err) => {
+          request.logger.error(
+            structureErrorForECS(err),
+            `Failed to update coastal operations areas for ${applicationReference}`
+          )
+        }),
+        updateMarinePlanningAreas(exemption, db, {
+          updatedAt,
+          updatedBy
+        }).catch((err) => {
+          request.logger.error(
+            structureErrorForECS(err),
+            `Failed to update marine plan areas for ${applicationReference}`
+          )
+        })
       ])
         .then(async () => {
           if (isDynamicsEnabled) {
@@ -150,7 +168,8 @@ export const submitExemptionController = {
         })
         .catch((err) => {
           request.logger.error(
-            `Background post-submit processing failed for ${applicationReference}: ${err.message}`
+            structureErrorForECS(err),
+            `Failed to insert queue entries for ${applicationReference}`
           )
         })
 

--- a/src/exemptions/api/controllers/submit-exemption.js
+++ b/src/exemptions/api/controllers/submit-exemption.js
@@ -122,27 +122,38 @@ export const submitExemptionController = {
         submittedAt,
         declarationAcceptedByContactId
       })
-      await Promise.all([
+      const { organisation } = exemption
+
+      // Run geo lookups, queue inserts and email in the background so the
+      // user receives applicationReference and submittedAt immediately.
+      // Geo writes must finish before the queue inserts because Dynamics/EMP
+      // read marinePlanAreas and coastalOperationsAreas off the exemption doc.
+      Promise.all([
         updateCoastalOperationsAreas(exemption, db, { updatedAt, updatedBy }),
         updateMarinePlanningAreas(exemption, db, { updatedAt, updatedBy })
       ])
-      if (isDynamicsEnabled) {
-        await addToDynamicsQueue({
-          request,
-          applicationReference,
-          action: DYNAMICS_REQUEST_ACTIONS.SUBMIT
+        .then(async () => {
+          if (isDynamicsEnabled) {
+            await addToDynamicsQueue({
+              request,
+              applicationReference,
+              action: DYNAMICS_REQUEST_ACTIONS.SUBMIT
+            })
+          }
+          if (isEmpEnabled) {
+            await addToEmpQueue({
+              request,
+              applicationReference,
+              action: EMP_REQUEST_ACTIONS.ADD
+            })
+          }
         })
-      }
-      if (isEmpEnabled) {
-        await addToEmpQueue({
-          request,
-          applicationReference,
-          action: EMP_REQUEST_ACTIONS.ADD
+        .catch((err) => {
+          request.logger.error(
+            `Background post-submit processing failed for ${applicationReference}: ${err.message}`
+          )
         })
-      }
 
-      const { organisation } = exemption
-      // async; don't wait for this to complete
       sendEmailConfirmation({
         db,
         userName,

--- a/src/exemptions/api/controllers/submit-exemption.js
+++ b/src/exemptions/api/controllers/submit-exemption.js
@@ -88,6 +88,61 @@ const updateExemptionRecord = async ({
   }
 }
 
+const runPostSubmitBackgroundWork = ({
+  exemption,
+  db,
+  updatedAt,
+  updatedBy,
+  applicationReference,
+  request,
+  isDynamicsEnabled,
+  isEmpEnabled
+}) => {
+  // Each geo operation catches its own errors so a failure in one does
+  // not block the other or the Dynamics/EMP queue inserts — geo areas
+  // can be backfilled independently via the backfill-areas endpoint.
+  Promise.all([
+    updateCoastalOperationsAreas(exemption, db, { updatedAt, updatedBy }).catch(
+      (err) => {
+        request.logger.error(
+          structureErrorForECS(err),
+          `Failed to update coastal operations areas for ${applicationReference}`
+        )
+      }
+    ),
+    updateMarinePlanningAreas(exemption, db, { updatedAt, updatedBy }).catch(
+      (err) => {
+        request.logger.error(
+          structureErrorForECS(err),
+          `Failed to update marine plan areas for ${applicationReference}`
+        )
+      }
+    )
+  ])
+    .then(async () => {
+      if (isDynamicsEnabled) {
+        await addToDynamicsQueue({
+          request,
+          applicationReference,
+          action: DYNAMICS_REQUEST_ACTIONS.SUBMIT
+        })
+      }
+      if (isEmpEnabled) {
+        await addToEmpQueue({
+          request,
+          applicationReference,
+          action: EMP_REQUEST_ACTIONS.ADD
+        })
+      }
+    })
+    .catch((err) => {
+      request.logger.error(
+        structureErrorForECS(err),
+        `Failed to insert queue entries for ${applicationReference}`
+      )
+    })
+}
+
 export const submitExemptionController = {
   options: {
     payload: {
@@ -127,51 +182,16 @@ export const submitExemptionController = {
 
       // Run geo lookups, queue inserts and email in the background so the
       // user receives applicationReference and submittedAt immediately.
-      // Each geo operation catches its own errors so a failure in one does
-      // not block the other or the Dynamics/EMP queue inserts — geo areas
-      // can be backfilled independently via the backfill-areas endpoint.
-      Promise.all([
-        updateCoastalOperationsAreas(exemption, db, {
-          updatedAt,
-          updatedBy
-        }).catch((err) => {
-          request.logger.error(
-            structureErrorForECS(err),
-            `Failed to update coastal operations areas for ${applicationReference}`
-          )
-        }),
-        updateMarinePlanningAreas(exemption, db, {
-          updatedAt,
-          updatedBy
-        }).catch((err) => {
-          request.logger.error(
-            structureErrorForECS(err),
-            `Failed to update marine plan areas for ${applicationReference}`
-          )
-        })
-      ])
-        .then(async () => {
-          if (isDynamicsEnabled) {
-            await addToDynamicsQueue({
-              request,
-              applicationReference,
-              action: DYNAMICS_REQUEST_ACTIONS.SUBMIT
-            })
-          }
-          if (isEmpEnabled) {
-            await addToEmpQueue({
-              request,
-              applicationReference,
-              action: EMP_REQUEST_ACTIONS.ADD
-            })
-          }
-        })
-        .catch((err) => {
-          request.logger.error(
-            structureErrorForECS(err),
-            `Failed to insert queue entries for ${applicationReference}`
-          )
-        })
+      runPostSubmitBackgroundWork({
+        exemption,
+        db,
+        updatedAt,
+        updatedBy,
+        applicationReference,
+        request,
+        isDynamicsEnabled,
+        isEmpEnabled
+      })
 
       sendEmailConfirmation({
         db,

--- a/src/exemptions/api/controllers/submit-exemption.js
+++ b/src/exemptions/api/controllers/submit-exemption.js
@@ -122,11 +122,10 @@ export const submitExemptionController = {
         submittedAt,
         declarationAcceptedByContactId
       })
-      await updateCoastalOperationsAreas(exemption, db, {
-        updatedAt,
-        updatedBy
-      })
-      await updateMarinePlanningAreas(exemption, db, { updatedAt, updatedBy })
+      await Promise.all([
+        updateCoastalOperationsAreas(exemption, db, { updatedAt, updatedBy }),
+        updateMarinePlanningAreas(exemption, db, { updatedAt, updatedBy })
+      ])
       if (isDynamicsEnabled) {
         await addToDynamicsQueue({
           request,

--- a/src/exemptions/api/controllers/submit-exemption.test.js
+++ b/src/exemptions/api/controllers/submit-exemption.test.js
@@ -310,6 +310,144 @@ describe('POST /exemption/submit', () => {
       expect(mockHandler.code).toHaveBeenCalledWith(200)
     })
 
+    it('should log ECS-formatted error and still add to queues if coastal operations areas update fails', async () => {
+      const mockExemption = {
+        _id: ObjectId.createFromHexString(mockExemptionId),
+        contactId: 'test-contact-id',
+        projectName: 'Test Marine Project',
+        publicRegister: { consent: 'no' },
+        multipleSiteDetails: { multipleSitesEnabled: false },
+        siteDetails: [
+          {
+            coordinatesType: 'point',
+            coordinates: { latitude: '54.978', longitude: '-1.617' }
+          }
+        ],
+        activityDescription: 'Test marine activity'
+      }
+
+      mockExemptionsCollection.findOne.mockResolvedValue(mockExemption)
+      mockExemptionsCollection.updateOne.mockResolvedValue({ matchedCount: 1 })
+      updateCoastalOperationsAreas.mockRejectedValueOnce(
+        new Error('Geo DB error')
+      )
+
+      await submitExemptionController.handler(
+        {
+          payload: { id: mockExemptionId, ...mockAuditPayload },
+          db: mockDb,
+          locker: mockLocker,
+          server: mockServer,
+          auth: mockAuth,
+          logger: mockLogger
+        },
+        mockHandler
+      )
+      await flushPromises()
+
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        expect.objectContaining({
+          error: expect.objectContaining({ message: 'Geo DB error' })
+        }),
+        'Failed to update coastal operations areas for EXE/2025/10001'
+      )
+      // Queue inserts should still happen despite geo failure
+      expect(mockDb.collection).toHaveBeenCalledWith('exemption-dynamics-queue')
+      expect(mockDb.collection).toHaveBeenCalledWith('exemption-emp-queue')
+      expect(mockHandler.code).toHaveBeenCalledWith(200)
+    })
+
+    it('should log ECS-formatted error and still add to queues if marine plan areas update fails', async () => {
+      const mockExemption = {
+        _id: ObjectId.createFromHexString(mockExemptionId),
+        contactId: 'test-contact-id',
+        projectName: 'Test Marine Project',
+        publicRegister: { consent: 'no' },
+        multipleSiteDetails: { multipleSitesEnabled: false },
+        siteDetails: [
+          {
+            coordinatesType: 'point',
+            coordinates: { latitude: '54.978', longitude: '-1.617' }
+          }
+        ],
+        activityDescription: 'Test marine activity'
+      }
+
+      mockExemptionsCollection.findOne.mockResolvedValue(mockExemption)
+      mockExemptionsCollection.updateOne.mockResolvedValue({ matchedCount: 1 })
+      updateMarinePlanningAreas.mockRejectedValueOnce(
+        new Error('Marine plan geo error')
+      )
+
+      await submitExemptionController.handler(
+        {
+          payload: { id: mockExemptionId, ...mockAuditPayload },
+          db: mockDb,
+          locker: mockLocker,
+          server: mockServer,
+          auth: mockAuth,
+          logger: mockLogger
+        },
+        mockHandler
+      )
+      await flushPromises()
+
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        expect.objectContaining({
+          error: expect.objectContaining({ message: 'Marine plan geo error' })
+        }),
+        'Failed to update marine plan areas for EXE/2025/10001'
+      )
+      // Queue inserts should still happen despite geo failure
+      expect(mockDb.collection).toHaveBeenCalledWith('exemption-dynamics-queue')
+      expect(mockDb.collection).toHaveBeenCalledWith('exemption-emp-queue')
+      expect(mockHandler.code).toHaveBeenCalledWith(200)
+    })
+
+    it('should log ECS-formatted error if queue inserts fail after geo operations succeed', async () => {
+      const mockExemption = {
+        _id: ObjectId.createFromHexString(mockExemptionId),
+        contactId: 'test-contact-id',
+        projectName: 'Test Marine Project',
+        publicRegister: { consent: 'no' },
+        multipleSiteDetails: { multipleSitesEnabled: false },
+        siteDetails: [
+          {
+            coordinatesType: 'point',
+            coordinates: { latitude: '54.978', longitude: '-1.617' }
+          }
+        ],
+        activityDescription: 'Test marine activity'
+      }
+
+      mockExemptionsCollection.findOne.mockResolvedValue(mockExemption)
+      mockExemptionsCollection.updateOne.mockResolvedValue({ matchedCount: 1 })
+      mockDynamicsQueueCollection.insertOne.mockRejectedValueOnce(
+        new Error('Queue insert failed')
+      )
+
+      await submitExemptionController.handler(
+        {
+          payload: { id: mockExemptionId, ...mockAuditPayload },
+          db: mockDb,
+          locker: mockLocker,
+          server: mockServer,
+          auth: mockAuth,
+          logger: mockLogger
+        },
+        mockHandler
+      )
+      await flushPromises()
+
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        expect.objectContaining({
+          error: expect.objectContaining({ message: 'Queue insert failed' })
+        }),
+        'Failed to insert queue entries for EXE/2025/10001'
+      )
+      expect(mockHandler.code).toHaveBeenCalledWith(200)
+    })
+
     it('should not insert request queue document when dynamics and EMP are not enabled when exemption is submitted', async () => {
       const mockExemption = {
         _id: ObjectId.createFromHexString(mockExemptionId),

--- a/src/exemptions/api/controllers/submit-exemption.test.js
+++ b/src/exemptions/api/controllers/submit-exemption.test.js
@@ -1,4 +1,8 @@
-import { vi } from 'vitest'
+import { vi, describe, it, expect, beforeEach } from 'vitest'
+
+// Flush all pending microtasks and macrotasks so fire-and-forget background
+// promise chains (geo writes → queue inserts) complete before asserting.
+const flushPromises = () => new Promise((resolve) => setTimeout(resolve, 0))
 import { submitExemptionController } from './submit-exemption.js'
 import { generateApplicationReference } from '../../../shared/helpers/reference-generator.js'
 import { createTaskList } from '../helpers/createTaskList.js'
@@ -214,6 +218,7 @@ describe('POST /exemption/submit', () => {
         },
         mockHandler
       )
+      await flushPromises()
 
       expect(updateCoastalOperationsAreas).toHaveBeenCalledWith(
         mockExemption,
@@ -288,6 +293,7 @@ describe('POST /exemption/submit', () => {
         },
         mockHandler
       )
+      await flushPromises()
 
       expect(mockServer.methods.processDynamicsQueue).toHaveBeenCalled()
       expect(mockServer.methods.processEmpQueue).toHaveBeenCalled()
@@ -380,6 +386,7 @@ describe('POST /exemption/submit', () => {
         },
         mockHandler
       )
+      await flushPromises()
 
       expect(mockDb.collection).toHaveBeenCalledWith('exemption-dynamics-queue')
       expect(mockDb.collection).toHaveBeenCalledWith('exemption-emp-queue')

--- a/src/exemptions/api/controllers/submit-exemption.test.js
+++ b/src/exemptions/api/controllers/submit-exemption.test.js
@@ -1,8 +1,4 @@
 import { vi, describe, it, expect, beforeEach } from 'vitest'
-
-// Flush all pending microtasks and macrotasks so fire-and-forget background
-// promise chains (geo writes → queue inserts) complete before asserting.
-const flushPromises = () => new Promise((resolve) => setTimeout(resolve, 0))
 import { submitExemptionController } from './submit-exemption.js'
 import { generateApplicationReference } from '../../../shared/helpers/reference-generator.js'
 import { createTaskList } from '../helpers/createTaskList.js'
@@ -13,6 +9,10 @@ import { REQUEST_QUEUE_STATUS } from '../../../shared/common/constants/request-q
 import { config } from '../../../config.js'
 import { updateMarinePlanningAreas } from '../../../shared/common/helpers/geo/update-marine-planning-areas.js'
 import { updateCoastalOperationsAreas } from '../../../shared/common/helpers/geo/update-coastal-operations-areas.js'
+
+// Flush all pending microtasks and macrotasks so fire-and-forget background
+// promise chains (geo writes → queue inserts) complete before asserting.
+const flushPromises = () => new Promise((resolve) => setTimeout(resolve, 0))
 
 vi.mock('notifications-node-client', () => ({
   NotifyClient: vi.fn().mockImplementation(function () {
@@ -146,6 +146,8 @@ describe('POST /exemption/submit', () => {
     }
 
     generateApplicationReference.mockResolvedValue('EXE/2025/10001')
+    updateCoastalOperationsAreas.mockResolvedValue(undefined)
+    updateMarinePlanningAreas.mockResolvedValue(undefined)
     createTaskList.mockReturnValue({
       projectName: 'COMPLETED',
       publicRegister: 'COMPLETED',


### PR DESCRIPTION
The /exemption/submit endpoint was blocking the HTTP response on two
independent geospatial DB operations (coastal operations areas and marine
plan areas), followed by the Dynamics and EMP queue inserts. For a 34-site
exemption this was taking ~30 seconds.

The user only needs applicationReference and submittedAt immediately. All
post-submit work — geo lookups, queue inserts, and email — can happen after
the response is sent.

**Changes**:
- Fire geo operations in the background (Promise.all, no await) so the
  handler responds as soon as updateExemptionRecord completes
- Chain Dynamics and EMP queue inserts into the .then() of the geo
  Promise.all to preserve the ordering guarantee (geo fields must be
  written before Dynamics reads them from the DB)
- Errors in the background chain are caught and logged against the
  applicationReference rather than surfaced as a 500