### PR TITLE
ML-1232: lcml activity limited to specific months page

### DIFF
--- a/src/marine-licences/api/controllers/update-site-details.integration.test.js
+++ b/src/marine-licences/api/controllers/update-site-details.integration.test.js
@@ -83,7 +83,7 @@ describe('PATCH /marine-licence/site-details - payload size limits', async () =>
           activityDescription: 'Test description',
           activityDuration: {},
           completionDate: '',
-          activityMonths: '',
+          activityMonths: {},
           workingHours: ''
         }
       ]

--- a/src/marine-licences/api/helpers/create-empty-activity-details.js
+++ b/src/marine-licences/api/helpers/create-empty-activity-details.js
@@ -3,6 +3,6 @@ export const createActivityDetails = () => ({
   activityDescription: '',
   activityDuration: {},
   completionDate: '',
-  activityMonths: '',
+  activityMonths: {},
   workingHours: ''
 })

--- a/src/marine-licences/api/helpers/createTaskList.js
+++ b/src/marine-licences/api/helpers/createTaskList.js
@@ -17,14 +17,22 @@ const ACTIVITY_DETAILS_FIELDS = [
   'workingHours'
 ]
 
+const isActivityFieldFilled = (activity, key) => {
+  if (key === 'activityMonths') {
+    return Boolean(activity.activityMonths?.months)
+  }
+
+  return Boolean(activity[key])
+}
+
 const checkActivityDetails = (activityDetails) => {
   if (!activityDetails?.length) {
     return IN_PROGRESS
   }
 
   for (const activity of activityDetails) {
-    const filledCount = ACTIVITY_DETAILS_FIELDS.filter(
-      (key) => activity[key]
+    const filledCount = ACTIVITY_DETAILS_FIELDS.filter((key) =>
+      isActivityFieldFilled(activity, key)
     ).length
 
     if (filledCount < ACTIVITY_DETAILS_FIELDS.length) {

--- a/src/marine-licences/api/helpers/createTaskList.test.js
+++ b/src/marine-licences/api/helpers/createTaskList.test.js
@@ -15,7 +15,7 @@ const completedActivityDetails = [
     activityDescription: 'Building a pier',
     activityDuration: '6 months',
     completionDate: '2025-06-01',
-    activityMonths: 'Jan, Feb',
+    activityMonths: { months: 'yes', details: 'Jan, Feb' },
     workingHours: '08:00-17:00'
   }
 ]
@@ -129,6 +129,24 @@ describe('createTaskList', () => {
           activityDetails: [
             completedActivityDetails[0],
             { ...completedActivityDetails[0], workingHours: '' }
+          ]
+        }
+      ]
+    }
+
+    expect(createTaskList(marineLicence).siteDetails).toBe(IN_PROGRESS)
+  })
+
+  it('should return siteDetails as IN_PROGRESS when activityMonths has no date', () => {
+    const marineLicence = {
+      projectName: 'Test Project',
+      specialLegalPowers: 'Some powers',
+      otherAuthorities: 'Some authorities',
+      siteDetails: [
+        {
+          ...mockFileUploadSite,
+          activityDetails: [
+            { ...completedActivityDetails[0], activityMonths: {} }
           ]
         }
       ]

--- a/src/marine-licences/models/activity-details/activity-details.js
+++ b/src/marine-licences/models/activity-details/activity-details.js
@@ -3,13 +3,14 @@ import { marineLicenceId } from '../shared-models.js'
 import { activityTypeFields } from './activity-type.js'
 import { activityDurationSchema } from './activity-duration.js'
 import { activityDescriptionSchema } from './activity-description.js'
+import { activityMonthsSchema } from './activity-months.js'
 
 export const activityItemSchema = joi.object({
   ...activityTypeFields,
   activityDescription: activityDescriptionSchema,
   activityDuration: activityDurationSchema,
   completionDate: joi.string().optional().allow(''),
-  activityMonths: joi.string().optional().allow(''),
+  activityMonths: activityMonthsSchema,
   workingHours: joi.string().optional().allow('')
 })
 

--- a/src/marine-licences/models/activity-details/activity-months.js
+++ b/src/marine-licences/models/activity-details/activity-months.js
@@ -1,0 +1,24 @@
+import joi from 'joi'
+
+export const MONTHS_OF_ACTIVITY_DETAILS_MAX_LENGTH = 1000
+
+export const activityMonthsSchema = joi.object({
+  months: joi.string().valid('yes', 'no').optional().messages({
+    'any.only': 'MONTHS_OF_ACTIVITY_REQUIRED',
+    'string.empty': 'MONTHS_OF_ACTIVITY_REQUIRED',
+    'any.required': 'MONTHS_OF_ACTIVITY_REQUIRED'
+  }),
+  details: joi.when('months', {
+    is: 'yes',
+    then: joi
+      .string()
+      .trim()
+      .max(MONTHS_OF_ACTIVITY_DETAILS_MAX_LENGTH)
+      .required()
+      .messages({
+        'string.empty': 'MONTHS_OF_ACTIVITY_DETAILS_REQUIRED',
+        'any.required': 'MONTHS_OF_ACTIVITY_DETAILS_REQUIRED',
+        'string.max': 'MONTHS_OF_ACTIVITY_DETAILS_MAX_LENGTH'
+      })
+  })
+})

--- a/src/marine-licences/models/activity-details/activity-months.test.js
+++ b/src/marine-licences/models/activity-details/activity-months.test.js
@@ -26,7 +26,7 @@ describe('activityMonths', () => {
   })
 
   test('should fail when reason length exceeds limit value', () => {
-    const longString = 't'.repeat(10000 + 1)
+    const longString = 't'.repeat(1_000 + 1)
     const { error } = schema.validate({
       activityMonths: { months: 'yes', details: longString }
     })

--- a/src/marine-licences/models/activity-details/activity-months.test.js
+++ b/src/marine-licences/models/activity-details/activity-months.test.js
@@ -1,0 +1,35 @@
+import joi from 'joi'
+import { activityMonthsSchema } from './activity-months.js'
+
+const schema = joi.object({ activityMonths: activityMonthsSchema })
+
+describe('activityMonths', () => {
+  test('should pass with correct values', () => {
+    const { error } = schema.validate({
+      activityMonths: { months: 'yes', details: 'Test reason' }
+    })
+    expect(error).toBeUndefined()
+  })
+
+  test('should fail when reason not provided or blank', () => {
+    const { error: missingError } = schema.validate({
+      activityMonths: { months: 'yes' }
+    })
+    expect(missingError.message).toContain(
+      'MONTHS_OF_ACTIVITY_DETAILS_REQUIRED'
+    )
+
+    const { error: blankError } = schema.validate({
+      activityMonths: { months: 'yes', details: '' }
+    })
+    expect(blankError.message).toContain('MONTHS_OF_ACTIVITY_DETAILS_REQUIRED')
+  })
+
+  test('should fail when reason length exceeds limit value', () => {
+    const longString = 't'.repeat(10000 + 1)
+    const { error } = schema.validate({
+      activityMonths: { months: 'yes', details: longString }
+    })
+    expect(error.message).toContain('MONTHS_OF_ACTIVITY_DETAILS_MAX_LENGTH')
+  })
+})

--- a/src/marine-licences/models/activity-details/completion-date.test.js
+++ b/src/marine-licences/models/activity-details/completion-date.test.js
@@ -24,7 +24,7 @@ describe('completionDate', () => {
   })
 
   test('should fail when reason length exceeds limit value', () => {
-    const longString = 't'.repeat(1000 + 1)
+    const longString = 't'.repeat(1_000 + 1)
     const { error } = schema.validate({
       completionDate: { date: 'yes', reason: longString }
     })


### PR DESCRIPTION
Schema for Activity Months:

- can be {} for creating blank activity dates
- months can be 'yes' or 'no'
- if 'yes' we need details. Same pattern used here as pages like Public Register that have conditional text input.

```json
"activityDetails": {
 "activityMonths" : {"months": "yes", "details": "reason goes here"}
}
```
Depends-On: https://github.com/DEFRA/marine-licensing-frontend/pull/649

