### PR TITLE
ML-1235: Delete Activity Details

### DIFF
--- a/src/marine-licences/api/controllers/delete-activity-details.integration.test.js
+++ b/src/marine-licences/api/controllers/delete-activity-details.integration.test.js
@@ -1,0 +1,111 @@
+import { setupTestServer } from '../../../../tests/test-server.js'
+import { makePatchRequest } from '../../../../tests/server-requests.js'
+import { ObjectId } from 'mongodb'
+import { mockMarineLicence } from '../../models/test-fixtures.js'
+import { createActivityDetails } from '../../api/helpers/create-empty-activity-details.js'
+
+describe('PATCH /marine-licence/delete-activity-details - integration tests', async () => {
+  const getServer = await setupTestServer()
+  const contactId = '123e4567-e89b-12d3-a456-426614174000'
+  const marineLicenceId = new ObjectId()
+
+  const emptyActivityDetails = createActivityDetails()
+
+  const buildPayload = (overrides = {}) => ({
+    id: marineLicenceId.toString(),
+    siteIndex: 0,
+    activityIndex: 0,
+    ...overrides
+  })
+
+  test('successfully deletes the activity at the given index', async () => {
+    const licenceId = new ObjectId()
+    const marineLicence = {
+      ...mockMarineLicence,
+      _id: licenceId,
+      contactId,
+      siteDetails: [
+        {
+          coordinatesType: 'manual',
+          activityDetails: [emptyActivityDetails, emptyActivityDetails]
+        }
+      ]
+    }
+
+    await globalThis.mockMongo
+      .collection('marine-licences')
+      .insertOne(marineLicence)
+
+    const { statusCode, body } = await makePatchRequest({
+      server: getServer(),
+      url: '/marine-licence/delete-activity-details',
+      contactId,
+      payload: buildPayload({ id: licenceId.toString() })
+    })
+
+    expect(statusCode).toBe(200)
+    expect(body).toEqual({ message: 'success' })
+
+    const updated = await globalThis.mockMongo
+      .collection('marine-licences')
+      .findOne({ _id: licenceId })
+
+    expect(updated.siteDetails[0].activityDetails).toHaveLength(1)
+  })
+
+  test('returns 404 when siteIndex is invalid', async () => {
+    const licenceId = new ObjectId()
+    const marineLicence = {
+      ...mockMarineLicence,
+      _id: licenceId,
+      contactId,
+      siteDetails: [
+        {
+          coordinatesType: 'manual',
+          activityDetails: [emptyActivityDetails]
+        }
+      ]
+    }
+
+    await globalThis.mockMongo
+      .collection('marine-licences')
+      .insertOne(marineLicence)
+
+    const { statusCode } = await makePatchRequest({
+      server: getServer(),
+      url: '/marine-licence/delete-activity-details',
+      contactId,
+      payload: buildPayload({ id: licenceId.toString(), siteIndex: 99 })
+    })
+
+    expect(statusCode).toBe(404)
+  })
+
+  test('returns 404 when activityIndex is invalid', async () => {
+    const licenceId = new ObjectId()
+    const marineLicence = {
+      ...mockMarineLicence,
+      _id: licenceId,
+      contactId,
+      siteDetails: [
+        {
+          coordinatesType: 'manual',
+          activityDetails: [emptyActivityDetails]
+        }
+      ]
+    }
+
+    await globalThis.mockMongo
+      .collection('marine-licences')
+      .insertOne(marineLicence)
+
+    const { statusCode } = await makePatchRequest({
+      server: getServer(),
+      url: '/marine-licence/delete-activity-details',
+      contactId,
+      payload: buildPayload({ id: licenceId.toString(), activityIndex: 99 })
+    })
+
+    expect(statusCode).toBe(404)
+  })
+})

--- a/src/marine-licences/api/controllers/delete-activity-details.js
+++ b/src/marine-licences/api/controllers/delete-activity-details.js
@@ -1,0 +1,71 @@
+import Boom from '@hapi/boom'
+import { deleteActivityDetailsSchema } from '../../models/activity-details/delete-activity-details.js'
+import { StatusCodes } from 'http-status-codes'
+import { ObjectId } from 'mongodb'
+import { collectionMarineLicences } from '../../../shared/common/constants/db-collections.js'
+import { authorizeOwnership } from '../../../shared/helpers/authorize-ownership.js'
+
+export const deleteActivityDetailsController = {
+  options: {
+    payload: {
+      parse: true,
+      output: 'data'
+    },
+    pre: [{ method: authorizeOwnership(collectionMarineLicences) }],
+    validate: {
+      query: false,
+      payload: deleteActivityDetailsSchema
+    }
+  },
+  handler: async (request, h) => {
+    try {
+      const { payload, db } = request
+      const { id, siteIndex, activityIndex, updatedAt, updatedBy } = payload
+
+      const activityDetailsPath = `siteDetails.${siteIndex}.activityDetails`
+      const activityPath = `${activityDetailsPath}.${activityIndex}`
+      const sitePath = `siteDetails.${siteIndex}`
+      const _id = ObjectId.createFromHexString(id)
+
+      const marineLicence = await db
+        .collection(collectionMarineLicences)
+        .findOne({ _id, [activityPath]: { $exists: true } })
+
+      if (!marineLicence) {
+        throw Boom.notFound(
+          `Activity Details not found for site ${siteIndex} and activity ${activityIndex} for Marine Licence ${id}`
+        )
+      }
+
+      // updatedAt here is used as a version to prevent collisions and users deleting other activities
+      const unsetResult = await db
+        .collection(collectionMarineLicences)
+        .updateOne(
+          {
+            _id,
+            [sitePath]: { $exists: true },
+            updatedAt: marineLicence.updatedAt
+          },
+          { $unset: { [activityPath]: 1 }, $set: { updatedAt, updatedBy } }
+        )
+
+      if (unsetResult.matchedCount === 0) {
+        throw Boom.conflict(
+          `Marine Licence ${id} was modified by another user. Please reload and try again.`
+        )
+      }
+
+      await db
+        .collection(collectionMarineLicences)
+        .updateOne({ _id }, { $pull: { [activityDetailsPath]: null } })
+
+      return h.response({ message: 'success' }).code(StatusCodes.OK)
+    } catch (error) {
+      if (error.isBoom) {
+        throw error
+      }
+
+      throw Boom.internal(`Error deleting activity details: ${error.message}`)
+    }
+  }
+}

--- a/src/marine-licences/api/controllers/delete-activity-details.test.js
+++ b/src/marine-licences/api/controllers/delete-activity-details.test.js
@@ -1,0 +1,127 @@
+import { vi } from 'vitest'
+import { ObjectId } from 'mongodb'
+import { deleteActivityDetailsController } from './delete-activity-details.js'
+import { createActivityDetails } from '../helpers/create-empty-activity-details.js'
+import Boom from '@hapi/boom'
+
+describe('PATCH /marine-licence/delete-activity-details', () => {
+  const mockAuditPayload = {
+    updatedAt: new Date('2025-01-01T12:00:00Z'),
+    updatedBy: 'user123'
+  }
+
+  const existingUpdatedAt = new Date('2024-12-01T10:00:00Z')
+  const emptyActivity = createActivityDetails()
+  const mockId = new ObjectId().toHexString()
+
+  const buildPayload = (overrides = {}) => ({
+    id: mockId,
+    siteIndex: 0,
+    activityIndex: 0,
+    ...mockAuditPayload,
+    ...overrides
+  })
+
+  const buildMarineLicence = (activities = [emptyActivity]) => ({
+    updatedAt: existingUpdatedAt,
+    siteDetails: [{ coordinatesType: 'manual', activityDetails: activities }]
+  })
+
+  describe('handler', () => {
+    it('should delete the activity at the given index from the correct site', async () => {
+      const { mockMongo, mockHandler } = global
+      const mockPayload = buildPayload()
+
+      const mockFindOne = vi.fn().mockResolvedValueOnce(buildMarineLicence())
+      const mockUpdateOne = vi.fn().mockResolvedValue({ matchedCount: 1 })
+      vi.spyOn(mockMongo, 'collection').mockImplementation(() => ({
+        findOne: mockFindOne,
+        updateOne: mockUpdateOne
+      }))
+
+      await deleteActivityDetailsController.handler(
+        { db: mockMongo, payload: mockPayload },
+        mockHandler
+      )
+
+      expect(mockHandler.response).toHaveBeenCalledWith({ message: 'success' })
+      expect(mockFindOne).toHaveBeenCalledWith({
+        _id: ObjectId.createFromHexString(mockPayload.id),
+        'siteDetails.0.activityDetails.0': { $exists: true }
+      })
+      expect(mockUpdateOne).toHaveBeenNthCalledWith(
+        1,
+        {
+          _id: ObjectId.createFromHexString(mockPayload.id),
+          'siteDetails.0': { $exists: true },
+          updatedAt: existingUpdatedAt
+        },
+        {
+          $unset: { 'siteDetails.0.activityDetails.0': 1 },
+          $set: mockAuditPayload
+        }
+      )
+      expect(mockUpdateOne).toHaveBeenNthCalledWith(
+        2,
+        { _id: ObjectId.createFromHexString(mockPayload.id) },
+        { $pull: { 'siteDetails.0.activityDetails': null } }
+      )
+    })
+
+    it('should throw 404 when marine licence not found or indexes are invalid', async () => {
+      const { mockMongo, mockHandler } = global
+      const mockPayload = buildPayload({ siteIndex: 99 })
+
+      vi.spyOn(mockMongo, 'collection').mockImplementation(() => ({
+        findOne: vi.fn().mockResolvedValueOnce(null)
+      }))
+
+      vi.spyOn(Boom, 'notFound')
+
+      await expect(() =>
+        deleteActivityDetailsController.handler(
+          { db: mockMongo, payload: mockPayload },
+          mockHandler
+        )
+      ).rejects.toThrow(
+        `Activity Details not found for site 99 and activity 0 for Marine Licence ${mockId}`
+      )
+    })
+
+    it('should throw 409 when the document was modified by another user', async () => {
+      const { mockMongo, mockHandler } = global
+      const mockPayload = buildPayload()
+
+      vi.spyOn(mockMongo, 'collection').mockImplementation(() => ({
+        findOne: vi.fn().mockResolvedValueOnce(buildMarineLicence()),
+        updateOne: vi.fn().mockResolvedValueOnce({ matchedCount: 0 })
+      }))
+
+      vi.spyOn(Boom, 'conflict')
+
+      await expect(() =>
+        deleteActivityDetailsController.handler(
+          { db: mockMongo, payload: mockPayload },
+          mockHandler
+        )
+      ).rejects.toThrow('was modified by another user')
+    })
+
+    it('should throw a 500 when the database operation fails', async () => {
+      const { mockMongo, mockHandler } = global
+      const mockPayload = buildPayload()
+      const mockError = 'Database exploded'
+
+      vi.spyOn(mockMongo, 'collection').mockImplementation(() => ({
+        findOne: vi.fn().mockRejectedValueOnce(new Error(mockError))
+      }))
+
+      await expect(() =>
+        deleteActivityDetailsController.handler(
+          { db: mockMongo, payload: mockPayload },
+          mockHandler
+        )
+      ).rejects.toThrow(`Error deleting activity details: ${mockError}`)
+    })
+  })
+})

--- a/src/marine-licences/api/index.js
+++ b/src/marine-licences/api/index.js
@@ -9,6 +9,7 @@ import { updateOtherAuthoritiesController } from './controllers/update-other-aut
 import { updateProjectBackgroundController } from './controllers/update-project-background.js'
 import { updateSiteDetailsController } from './controllers/update-site-details.js'
 import { addActivityDetailsController } from './controllers/add-activity-details.js'
+import { deleteActivityDetailsController } from './controllers/delete-activity-details.js'
 import { updateSiteController } from './controllers/update-site.js'
 
 export const marineLicences = [
@@ -66,6 +67,11 @@ export const marineLicences = [
     method: 'PATCH',
     path: '/marine-licence/add-activity-details',
     ...addActivityDetailsController
+  },
+  {
+    method: 'PATCH',
+    path: '/marine-licence/delete-activity-details',
+    ...deleteActivityDetailsController
   },
   {
     method: 'PATCH',

--- a/src/marine-licences/models/activity-details/delete-activity-details.js
+++ b/src/marine-licences/models/activity-details/delete-activity-details.js
@@ -1,0 +1,19 @@
+import joi from 'joi'
+import { marineLicenceId } from '../shared-models.js'
+
+export const deleteActivityDetailsSchema = joi
+  .object({
+    siteIndex: joi.number().integer().min(0).required().messages({
+      'number.base': 'SITE_INDEX_REQUIRED',
+      'number.integer': 'SITE_INDEX_INVALID',
+      'number.min': 'SITE_INDEX_INVALID',
+      'any.required': 'SITE_INDEX_REQUIRED'
+    }),
+    activityIndex: joi.number().integer().min(0).required().messages({
+      'number.base': 'ACTIVITY_INDEX_REQUIRED',
+      'number.integer': 'ACTIVITY_INDEX_INVALID',
+      'number.min': 'ACTIVITY_INDEX_INVALID',
+      'any.required': 'ACTIVITY_INDEX_REQUIRED'
+    })
+  })
+  .append(marineLicenceId)

--- a/src/marine-licences/models/activity-details/delete-activity-details.test.js
+++ b/src/marine-licences/models/activity-details/delete-activity-details.test.js
@@ -1,0 +1,85 @@
+import { ObjectId } from 'mongodb'
+import { deleteActivityDetailsSchema } from './delete-activity-details.js'
+
+describe('deleteActivityDetailsSchema', () => {
+  const validPayload = {
+    id: new ObjectId().toHexString(),
+    siteIndex: 0,
+    activityIndex: 0
+  }
+
+  test('should pass with valid payload', () => {
+    const { error } = deleteActivityDetailsSchema.validate(validPayload)
+    expect(error).toBeUndefined()
+  })
+
+  describe('siteIndex', () => {
+    test('should fail when siteIndex is missing', () => {
+      const { error } = deleteActivityDetailsSchema.validate({
+        ...validPayload,
+        siteIndex: undefined
+      })
+      expect(error.message).toContain('SITE_INDEX_REQUIRED')
+    })
+
+    test('should fail when siteIndex is negative', () => {
+      const { error } = deleteActivityDetailsSchema.validate({
+        ...validPayload,
+        siteIndex: -1
+      })
+      expect(error.message).toContain('SITE_INDEX_INVALID')
+    })
+
+    test('should fail when siteIndex is not an integer', () => {
+      const { error } = deleteActivityDetailsSchema.validate({
+        ...validPayload,
+        siteIndex: 1.5
+      })
+      expect(error.message).toContain('SITE_INDEX_INVALID')
+    })
+  })
+
+  describe('activityIndex', () => {
+    test('should fail when activityIndex is missing', () => {
+      const { error } = deleteActivityDetailsSchema.validate({
+        ...validPayload,
+        activityIndex: undefined
+      })
+      expect(error.message).toContain('ACTIVITY_INDEX_REQUIRED')
+    })
+
+    test('should fail when activityIndex is negative', () => {
+      const { error } = deleteActivityDetailsSchema.validate({
+        ...validPayload,
+        activityIndex: -1
+      })
+      expect(error.message).toContain('ACTIVITY_INDEX_INVALID')
+    })
+
+    test('should fail when activityIndex is not an integer', () => {
+      const { error } = deleteActivityDetailsSchema.validate({
+        ...validPayload,
+        activityIndex: 1.5
+      })
+      expect(error.message).toContain('ACTIVITY_INDEX_INVALID')
+    })
+  })
+
+  describe('id', () => {
+    test('should fail when id is missing', () => {
+      const { error } = deleteActivityDetailsSchema.validate({
+        ...validPayload,
+        id: undefined
+      })
+      expect(error.message).toContain('MARINE_LICENCE_ID_REQUIRED')
+    })
+
+    test('should fail when id is not a valid hex string', () => {
+      const { error } = deleteActivityDetailsSchema.validate({
+        ...validPayload,
+        id: 'z'.repeat(24)
+      })
+      expect(error.message).toContain('MARINE_LICENCE_ID_INVALID')
+    })
+  })
+})


### PR DESCRIPTION
- Patch '/marine-licence/delete-activity-details' with siteIndex and activityIndex.
- Check to see if the values exist to prevent a delete operation on something that does not exist.
- Use the updatedAt value to prevent the possibility another user from doing a delete at the same time. This would be an issue due to having an index value for the activityIndex, if two users did a delete at the same time it would delete incorrect data.