### PR TITLE
ML-1291 Add internal exemption summary counts endpoint

### DIFF
--- a/src/exemptions/api/controllers/get-exemption-summary.integration.test.js
+++ b/src/exemptions/api/controllers/get-exemption-summary.integration.test.js
@@ -1,0 +1,72 @@
+import { setupTestServer } from '../../../../tests/test-server.js'
+import { makeGetRequest } from '../../../../tests/server-requests.js'
+import { createCompleteExemption } from '../../../../tests/test.fixture.js'
+import { EXEMPTION_STATUS } from '../../constants/exemption.js'
+import { collectionExemptions } from '../../../shared/common/constants/db-collections.js'
+import { ObjectId } from 'mongodb'
+
+describe('Get exemption summary - integration tests', async () => {
+  const getServer = await setupTestServer()
+
+  beforeEach(async () => {
+    await globalThis.mockMongo.collection(collectionExemptions).deleteMany({})
+  })
+
+  test('returns aggregated counts for internal users', async () => {
+    const exemptions = [
+      createCompleteExemption({
+        _id: new ObjectId(),
+        status: EXEMPTION_STATUS.ACTIVE
+      }),
+      createCompleteExemption({
+        _id: new ObjectId(),
+        status: EXEMPTION_STATUS.ACTIVE
+      }),
+      createCompleteExemption({
+        _id: new ObjectId(),
+        status: EXEMPTION_STATUS.SUBMITTED
+      }),
+      createCompleteExemption({
+        _id: new ObjectId(),
+        status: EXEMPTION_STATUS.DRAFT
+      }),
+      createCompleteExemption({
+        _id: new ObjectId(),
+        status: EXEMPTION_STATUS.WITHDRAWN
+      })
+    ]
+
+    await globalThis.mockMongo
+      .collection(collectionExemptions)
+      .insertMany(exemptions)
+
+    const { statusCode, body } = await makeGetRequest({
+      server: getServer(),
+      url: '/exemptions/summary',
+      isInternalUser: true
+    })
+
+    expect(statusCode).toBe(200)
+    expect(body).toEqual({
+      submittedExemptions: 3,
+      unsubmittedExemptions: 1,
+      withdrawnExemptions: 1
+    })
+  })
+
+  test('returns 403 for applicant users', async () => {
+    const response = await getServer().inject({
+      auth: {
+        strategy: 'jwt',
+        credentials: { contactId: 'applicant-user' },
+        artifacts: { decoded: {} }
+      },
+      method: 'GET',
+      url: '/exemptions/summary'
+    })
+    const parsed = JSON.parse(response.payload)
+
+    expect(response.statusCode).toBe(403)
+    expect(parsed.message).toBe('Not authorised to request this resource')
+  })
+})

--- a/src/exemptions/api/controllers/get-exemption-summary.integration.test.js
+++ b/src/exemptions/api/controllers/get-exemption-summary.integration.test.js
@@ -1,12 +1,21 @@
-import { setupTestServer } from '../../../../tests/test-server.js'
 import { makeGetRequest } from '../../../../tests/server-requests.js'
 import { createCompleteExemption } from '../../../../tests/test.fixture.js'
 import { EXEMPTION_STATUS } from '../../constants/exemption.js'
 import { collectionExemptions } from '../../../shared/common/constants/db-collections.js'
 import { ObjectId } from 'mongodb'
 
-describe('Get exemption summary - integration tests', async () => {
-  const getServer = await setupTestServer()
+describe('Get exemption summary - integration tests', () => {
+  let server
+
+  beforeAll(async () => {
+    const { createServer } = await import('../../../server.js')
+    server = await createServer()
+    await server.initialize()
+  })
+
+  afterAll(async () => {
+    await server?.stop()
+  })
 
   beforeEach(async () => {
     await globalThis.mockMongo.collection(collectionExemptions).deleteMany({})
@@ -41,7 +50,7 @@ describe('Get exemption summary - integration tests', async () => {
       .insertMany(exemptions)
 
     const { statusCode, body } = await makeGetRequest({
-      server: getServer(),
+      server,
       url: '/exemptions/summary',
       isInternalUser: true
     })
@@ -55,7 +64,7 @@ describe('Get exemption summary - integration tests', async () => {
   })
 
   test('returns 403 for applicant users', async () => {
-    const response = await getServer().inject({
+    const response = await server.inject({
       auth: {
         strategy: 'jwt',
         credentials: { contactId: 'applicant-user' },

--- a/src/exemptions/api/controllers/get-exemption-summary.integration.test.js
+++ b/src/exemptions/api/controllers/get-exemption-summary.integration.test.js
@@ -62,20 +62,4 @@ describe('Get exemption summary - integration tests', () => {
       withdrawnExemptions: 1
     })
   })
-
-  test('returns 403 for applicant users', async () => {
-    const response = await server.inject({
-      auth: {
-        strategy: 'jwt',
-        credentials: { contactId: 'applicant-user' },
-        artifacts: { decoded: {} }
-      },
-      method: 'GET',
-      url: '/exemptions/summary'
-    })
-    const parsed = JSON.parse(response.payload)
-
-    expect(response.statusCode).toBe(403)
-    expect(parsed.message).toBe('Not authorised to request this resource')
-  })
 })

--- a/src/exemptions/api/controllers/get-exemption-summary.js
+++ b/src/exemptions/api/controllers/get-exemption-summary.js
@@ -1,0 +1,48 @@
+import Boom from '@hapi/boom'
+import { StatusCodes } from 'http-status-codes'
+import { collectionExemptions } from '../../../shared/common/constants/db-collections.js'
+import { EXEMPTION_STATUS } from '../../constants/exemption.js'
+import { isApplicantUser } from '../helpers/is-applicant-user.js'
+
+export const getExemptionSummaryController = {
+  handler: async (request, h) => {
+    try {
+      if (isApplicantUser(request)) {
+        throw Boom.forbidden('Not authorised to request this resource')
+      }
+
+      const { db } = request
+      const groupedStatusCounts = await db
+        .collection(collectionExemptions)
+        .aggregate([{ $group: { _id: '$status', count: { $sum: 1 } } }])
+        .toArray()
+
+      const countsByStatus = groupedStatusCounts.reduce((acc, item) => {
+        acc[item._id] = item.count
+        return acc
+      }, {})
+
+      const submittedExemptions =
+        (countsByStatus[EXEMPTION_STATUS.ACTIVE] ?? 0) +
+        (countsByStatus[EXEMPTION_STATUS.SUBMITTED] ?? 0)
+
+      return h
+        .response({
+          message: 'success',
+          value: {
+            submittedExemptions,
+            unsubmittedExemptions: countsByStatus[EXEMPTION_STATUS.DRAFT] ?? 0,
+            withdrawnExemptions: countsByStatus[EXEMPTION_STATUS.WITHDRAWN] ?? 0
+          }
+        })
+        .code(StatusCodes.OK)
+    } catch (error) {
+      if (error.isBoom) {
+        throw error
+      }
+      throw Boom.internal(
+        `Error retrieving exemption summary: ${error.message}`
+      )
+    }
+  }
+}

--- a/src/exemptions/api/controllers/get-exemption-summary.js
+++ b/src/exemptions/api/controllers/get-exemption-summary.js
@@ -1,16 +1,12 @@
 import Boom from '@hapi/boom'
 import { StatusCodes } from 'http-status-codes'
 import { collectionExemptions } from '../../../shared/common/constants/db-collections.js'
+import { structureErrorForECS } from '../../../shared/common/helpers/logging/logger.js'
 import { EXEMPTION_STATUS } from '../../constants/exemption.js'
-import { isApplicantUser } from '../helpers/is-applicant-user.js'
 
 export const getExemptionSummaryController = {
   handler: async (request, h) => {
     try {
-      if (isApplicantUser(request)) {
-        throw Boom.forbidden('Not authorised to request this resource')
-      }
-
       const { db } = request
       const groupedStatusCounts = await db
         .collection(collectionExemptions)
@@ -54,6 +50,10 @@ export const getExemptionSummaryController = {
       if (error.isBoom) {
         throw error
       }
+      request.logger.error(
+        structureErrorForECS(error),
+        'Failed to retrieve exemption summary'
+      )
       throw Boom.internal(
         `Error retrieving exemption summary: ${error.message}`
       )

--- a/src/exemptions/api/controllers/get-exemption-summary.js
+++ b/src/exemptions/api/controllers/get-exemption-summary.js
@@ -14,7 +14,21 @@ export const getExemptionSummaryController = {
       const { db } = request
       const groupedStatusCounts = await db
         .collection(collectionExemptions)
-        .aggregate([{ $group: { _id: '$status', count: { $sum: 1 } } }])
+        .aggregate([
+          {
+            $match: {
+              status: {
+                $in: [
+                  EXEMPTION_STATUS.ACTIVE,
+                  EXEMPTION_STATUS.SUBMITTED,
+                  EXEMPTION_STATUS.DRAFT,
+                  EXEMPTION_STATUS.WITHDRAWN
+                ]
+              }
+            }
+          },
+          { $group: { _id: '$status', count: { $sum: 1 } } }
+        ])
         .toArray()
 
       const countsByStatus = groupedStatusCounts.reduce((acc, item) => {

--- a/src/exemptions/api/controllers/get-exemption-summary.test.js
+++ b/src/exemptions/api/controllers/get-exemption-summary.test.js
@@ -1,0 +1,90 @@
+import { vi, expect } from 'vitest'
+import Boom from '@hapi/boom'
+import { getExemptionSummaryController } from './get-exemption-summary.js'
+import { EXEMPTION_STATUS } from '../../constants/exemption.js'
+
+describe('GET /exemptions/summary', () => {
+  let mockDb
+  let mockHandler
+
+  beforeEach(() => {
+    mockHandler = {
+      response: vi.fn().mockReturnThis(),
+      code: vi.fn().mockReturnThis()
+    }
+  })
+
+  it('returns status counts for internal users', async () => {
+    mockDb = {
+      collection: vi.fn().mockReturnValue({
+        aggregate: vi.fn().mockReturnValue({
+          toArray: vi.fn().mockResolvedValue([
+            { _id: EXEMPTION_STATUS.ACTIVE, count: 4 },
+            { _id: EXEMPTION_STATUS.SUBMITTED, count: 2 },
+            { _id: EXEMPTION_STATUS.DRAFT, count: 3 },
+            { _id: EXEMPTION_STATUS.WITHDRAWN, count: 1 }
+          ])
+        })
+      })
+    }
+
+    const request = {
+      db: mockDb,
+      auth: { artifacts: { decoded: { tid: 'entra-tenant-id' } } }
+    }
+
+    await getExemptionSummaryController.handler(request, mockHandler)
+
+    expect(mockHandler.response).toHaveBeenCalledWith({
+      message: 'success',
+      value: {
+        submittedExemptions: 6,
+        unsubmittedExemptions: 3,
+        withdrawnExemptions: 1
+      }
+    })
+    expect(mockHandler.code).toHaveBeenCalledWith(200)
+  })
+
+  it('returns zero counts when statuses are missing', async () => {
+    mockDb = {
+      collection: vi.fn().mockReturnValue({
+        aggregate: vi.fn().mockReturnValue({
+          toArray: vi.fn().mockResolvedValue([])
+        })
+      })
+    }
+
+    const request = {
+      db: mockDb,
+      auth: { artifacts: { decoded: { tid: 'entra-tenant-id' } } }
+    }
+
+    await getExemptionSummaryController.handler(request, mockHandler)
+
+    expect(mockHandler.response).toHaveBeenCalledWith({
+      message: 'success',
+      value: {
+        submittedExemptions: 0,
+        unsubmittedExemptions: 0,
+        withdrawnExemptions: 0
+      }
+    })
+  })
+
+  it('returns forbidden for applicant users', async () => {
+    mockDb = {
+      collection: vi.fn()
+    }
+    const request = {
+      db: mockDb,
+      auth: { artifacts: { decoded: {} } }
+    }
+
+    await expect(
+      getExemptionSummaryController.handler(request, mockHandler)
+    ).rejects.toThrow(Boom.forbidden('Not authorised to request this resource'))
+
+    expect(mockDb.collection).not.toHaveBeenCalled()
+  })
+})

--- a/src/exemptions/api/controllers/get-exemption-summary.test.js
+++ b/src/exemptions/api/controllers/get-exemption-summary.test.js
@@ -1,5 +1,4 @@
 import { vi, expect } from 'vitest'
-import Boom from '@hapi/boom'
 import { getExemptionSummaryController } from './get-exemption-summary.js'
 import { EXEMPTION_STATUS } from '../../constants/exemption.js'
 
@@ -7,9 +6,13 @@ describe('GET /exemptions/summary', () => {
   let mockDb
   let mockHandler
   let mockAggregate
+  let mockLogger
 
   beforeEach(() => {
     mockAggregate = vi.fn()
+    mockLogger = {
+      error: vi.fn()
+    }
     mockHandler = {
       response: vi.fn().mockReturnThis(),
       code: vi.fn().mockReturnThis()
@@ -32,7 +35,8 @@ describe('GET /exemptions/summary', () => {
 
     const request = {
       db: mockDb,
-      auth: { artifacts: { decoded: { tid: 'entra-tenant-id' } } }
+      auth: { artifacts: { decoded: { tid: 'entra-tenant-id' } } },
+      logger: mockLogger
     }
 
     await getExemptionSummaryController.handler(request, mockHandler)
@@ -74,7 +78,8 @@ describe('GET /exemptions/summary', () => {
 
     const request = {
       db: mockDb,
-      auth: { artifacts: { decoded: { tid: 'entra-tenant-id' } } }
+      auth: { artifacts: { decoded: { tid: 'entra-tenant-id' } } },
+      logger: mockLogger
     }
 
     await getExemptionSummaryController.handler(request, mockHandler)
@@ -89,22 +94,6 @@ describe('GET /exemptions/summary', () => {
     })
   })
 
-  it('returns forbidden for applicant users', async () => {
-    mockDb = {
-      collection: vi.fn()
-    }
-    const request = {
-      db: mockDb,
-      auth: { artifacts: { decoded: {} } }
-    }
-
-    await expect(
-      getExemptionSummaryController.handler(request, mockHandler)
-    ).rejects.toThrow(Boom.forbidden('Not authorised to request this resource'))
-
-    expect(mockDb.collection).not.toHaveBeenCalled()
-  })
-
   it('returns internal server error when aggregation fails', async () => {
     mockDb = {
       collection: vi.fn().mockReturnValue({
@@ -116,11 +105,22 @@ describe('GET /exemptions/summary', () => {
 
     const request = {
       db: mockDb,
-      auth: { artifacts: { decoded: { tid: 'entra-tenant-id' } } }
+      auth: { artifacts: { decoded: { tid: 'entra-tenant-id' } } },
+      logger: mockLogger
     }
 
     await expect(
       getExemptionSummaryController.handler(request, mockHandler)
     ).rejects.toThrow('Error retrieving exemption summary: db unavailable')
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      expect.objectContaining({
+        error: expect.objectContaining({
+          message: 'db unavailable',
+          type: 'Error',
+          stack_trace: expect.any(String)
+        })
+      }),
+      'Failed to retrieve exemption summary'
+    )
   })
 })

--- a/src/exemptions/api/controllers/get-exemption-summary.test.js
+++ b/src/exemptions/api/controllers/get-exemption-summary.test.js
@@ -1,4 +1,5 @@
 import { vi, expect } from 'vitest'
+import Boom from '@hapi/boom'
 import { getExemptionSummaryController } from './get-exemption-summary.js'
 import { EXEMPTION_STATUS } from '../../constants/exemption.js'
 
@@ -122,5 +123,27 @@ describe('GET /exemptions/summary', () => {
       }),
       'Failed to retrieve exemption summary'
     )
+  })
+
+  it('rethrows boom errors without additional logging', async () => {
+    const boomError = Boom.badRequest('invalid aggregation')
+    mockDb = {
+      collection: vi.fn().mockReturnValue({
+        aggregate: vi.fn().mockReturnValue({
+          toArray: vi.fn().mockRejectedValue(boomError)
+        })
+      })
+    }
+
+    const request = {
+      db: mockDb,
+      auth: { artifacts: { decoded: { tid: 'entra-tenant-id' } } },
+      logger: mockLogger
+    }
+
+    await expect(
+      getExemptionSummaryController.handler(request, mockHandler)
+    ).rejects.toBe(boomError)
+    expect(mockLogger.error).not.toHaveBeenCalled()
   })
 })

--- a/src/exemptions/api/controllers/get-exemption-summary.test.js
+++ b/src/exemptions/api/controllers/get-exemption-summary.test.js
@@ -6,8 +6,10 @@ import { EXEMPTION_STATUS } from '../../constants/exemption.js'
 describe('GET /exemptions/summary', () => {
   let mockDb
   let mockHandler
+  let mockAggregate
 
   beforeEach(() => {
+    mockAggregate = vi.fn()
     mockHandler = {
       response: vi.fn().mockReturnThis(),
       code: vi.fn().mockReturnThis()
@@ -17,7 +19,7 @@ describe('GET /exemptions/summary', () => {
   it('returns status counts for internal users', async () => {
     mockDb = {
       collection: vi.fn().mockReturnValue({
-        aggregate: vi.fn().mockReturnValue({
+        aggregate: mockAggregate.mockReturnValue({
           toArray: vi.fn().mockResolvedValue([
             { _id: EXEMPTION_STATUS.ACTIVE, count: 4 },
             { _id: EXEMPTION_STATUS.SUBMITTED, count: 2 },
@@ -44,6 +46,21 @@ describe('GET /exemptions/summary', () => {
       }
     })
     expect(mockHandler.code).toHaveBeenCalledWith(200)
+    expect(mockAggregate).toHaveBeenCalledWith([
+      {
+        $match: {
+          status: {
+            $in: [
+              EXEMPTION_STATUS.ACTIVE,
+              EXEMPTION_STATUS.SUBMITTED,
+              EXEMPTION_STATUS.DRAFT,
+              EXEMPTION_STATUS.WITHDRAWN
+            ]
+          }
+        }
+      },
+      { $group: { _id: '$status', count: { $sum: 1 } } }
+    ])
   })
 
   it('returns zero counts when statuses are missing', async () => {
@@ -86,5 +103,24 @@ describe('GET /exemptions/summary', () => {
     ).rejects.toThrow(Boom.forbidden('Not authorised to request this resource'))
 
     expect(mockDb.collection).not.toHaveBeenCalled()
+  })
+
+  it('returns internal server error when aggregation fails', async () => {
+    mockDb = {
+      collection: vi.fn().mockReturnValue({
+        aggregate: vi.fn().mockReturnValue({
+          toArray: vi.fn().mockRejectedValue(new Error('db unavailable'))
+        })
+      })
+    }
+
+    const request = {
+      db: mockDb,
+      auth: { artifacts: { decoded: { tid: 'entra-tenant-id' } } }
+    }
+
+    await expect(
+      getExemptionSummaryController.handler(request, mockHandler)
+    ).rejects.toThrow('Error retrieving exemption summary: db unavailable')
   })
 })

--- a/src/exemptions/api/index.js
+++ b/src/exemptions/api/index.js
@@ -9,6 +9,7 @@ import { deleteExemptionController } from './controllers/delete-exemption.js'
 import { sendToEmpController } from './controllers/send-to-emp.js'
 import { withdrawExemptionController } from './controllers/withdraw-exemption.js'
 import { getBackfillAreasExemptionsController } from './controllers/get-backfill-areas.js'
+import { getExemptionSummaryController } from './controllers/get-exemption-summary.js'
 import { backfillAreasController } from './controllers/backfill-areas.js'
 
 export const exemptions = [
@@ -31,6 +32,11 @@ export const exemptions = [
     method: 'GET',
     path: '/exemptions/backfill-areas',
     ...getBackfillAreasExemptionsController
+  },
+  {
+    method: 'GET',
+    path: '/exemptions/summary',
+    ...getExemptionSummaryController
   },
   {
     method: 'POST',


### PR DESCRIPTION
Adds a new GET /exemptions/summary API for internal users that returns aggregated exemption counts (submittedExemptions, unsubmittedExemptions, and withdrawnExemptions) from MongoDB status data.
Includes route wiring plus unit and integration tests, and enforces a 403 response for applicant users.