### PR TITLE
ML-1243: lcml preferred start and end dates of the licence page

### DIFF
--- a/src/marine-licences/api/controllers/get-marine-licence.integration.test.js
+++ b/src/marine-licences/api/controllers/get-marine-licence.integration.test.js
@@ -46,10 +46,7 @@ describe('Get marine licence - integration tests', async () => {
       id: _id.toString(),
       createdAt: marineLicence.createdAt.toISOString(),
       updatedAt: marineLicence.updatedAt.toISOString(),
-      preferredDates: {
-        start: preferredDates.start.toISOString(),
-        end: preferredDates.end.toISOString()
-      },
+      preferredDates,
       taskList: {
         projectName: 'COMPLETED',
         otherAuthorities: 'INCOMPLETE',
@@ -90,10 +87,7 @@ describe('Get marine licence - integration tests', async () => {
       id: _id.toString(),
       createdAt: marineLicence.createdAt.toISOString(),
       updatedAt: marineLicence.updatedAt.toISOString(),
-      preferredDates: {
-        start: preferredDates.start.toISOString(),
-        end: preferredDates.end.toISOString()
-      },
+      preferredDates,
       whoMarineLicenceIsFor: 'Dave Barnett',
       taskList: {
         projectName: 'COMPLETED',

--- a/src/marine-licences/api/controllers/get-marine-licence.integration.test.js
+++ b/src/marine-licences/api/controllers/get-marine-licence.integration.test.js
@@ -40,12 +40,16 @@ describe('Get marine licence - integration tests', async () => {
     })
     expect(statusCode).toBe(200)
 
-    const { _id, ...rest } = marineLicence
+    const { _id, preferredDates, ...rest } = marineLicence
     expect(body).toEqual({
       ...rest,
       id: _id.toString(),
       createdAt: marineLicence.createdAt.toISOString(),
       updatedAt: marineLicence.updatedAt.toISOString(),
+      preferredDates: {
+        start: preferredDates.start.toISOString(),
+        end: preferredDates.end.toISOString()
+      },
       taskList: {
         projectName: 'COMPLETED',
         otherAuthorities: 'INCOMPLETE',
@@ -79,12 +83,16 @@ describe('Get marine licence - integration tests', async () => {
     })
     expect(statusCode).toBe(200)
 
-    const { _id, ...rest } = marineLicence
+    const { _id, preferredDates, ...rest } = marineLicence
     expect(body).toEqual({
       ...rest,
       id: _id.toString(),
       createdAt: marineLicence.createdAt.toISOString(),
       updatedAt: marineLicence.updatedAt.toISOString(),
+      preferredDates: {
+        start: preferredDates.start.toISOString(),
+        end: preferredDates.end.toISOString()
+      },
       whoMarineLicenceIsFor: 'Dave Barnett',
       taskList: {
         projectName: 'COMPLETED',

--- a/src/marine-licences/api/controllers/get-marine-licence.integration.test.js
+++ b/src/marine-licences/api/controllers/get-marine-licence.integration.test.js
@@ -53,6 +53,7 @@ describe('Get marine licence - integration tests', async () => {
       taskList: {
         projectName: 'COMPLETED',
         otherAuthorities: 'INCOMPLETE',
+        preferredDates: 'COMPLETED',
         projectBackground: 'INCOMPLETE',
         publicRegister: 'COMPLETED',
         siteDetails: 'INCOMPLETE'
@@ -97,6 +98,7 @@ describe('Get marine licence - integration tests', async () => {
       taskList: {
         projectName: 'COMPLETED',
         otherAuthorities: 'INCOMPLETE',
+        preferredDates: 'COMPLETED',
         projectBackground: 'INCOMPLETE',
         siteDetails: 'INCOMPLETE',
         publicRegister: 'COMPLETED'

--- a/src/marine-licences/api/controllers/get-marine-licence.test.js
+++ b/src/marine-licences/api/controllers/get-marine-licence.test.js
@@ -2,6 +2,7 @@ import { getMarineLicenceController } from './get-marine-licence.js'
 import { vi } from 'vitest'
 import { requestFromApplicantUser } from '../../../../.vite/mocks.js'
 import { MARINE_LICENCE_STATUS } from '../../constants/marine-licence.js'
+import { preferredDates } from '../../models/test-fixtures.js'
 
 describe('GET /marine-licence', () => {
   const authenticatedController = getMarineLicenceController({
@@ -89,6 +90,10 @@ describe('GET /marine-licence', () => {
           consent: 'yes',
           reason: 'Test public register reason'
         },
+        preferredDates: {
+          start: preferredDates.start.toISOString(),
+          end: preferredDates.end.toISOString()
+        },
         otherAuthorities: 'Test authority',
         projectBackground: 'Test project background',
         contactId: userContactId
@@ -113,9 +118,14 @@ describe('GET /marine-licence', () => {
               consent: 'yes',
               reason: 'Test public register reason'
             },
+            preferredDates: {
+              start: preferredDates.start.toISOString(),
+              end: preferredDates.end.toISOString()
+            },
             otherAuthorities: 'Test authority',
             projectBackground: 'Test project background',
             taskList: {
+              preferredDates: 'COMPLETED',
               projectName: 'COMPLETED',
               otherAuthorities: 'COMPLETED',
               projectBackground: 'COMPLETED',

--- a/src/marine-licences/api/controllers/get-marine-licence.test.js
+++ b/src/marine-licences/api/controllers/get-marine-licence.test.js
@@ -90,10 +90,7 @@ describe('GET /marine-licence', () => {
           consent: 'yes',
           reason: 'Test public register reason'
         },
-        preferredDates: {
-          start: preferredDates.start.toISOString(),
-          end: preferredDates.end.toISOString()
-        },
+        preferredDates,
         otherAuthorities: 'Test authority',
         projectBackground: 'Test project background',
         contactId: userContactId
@@ -118,10 +115,7 @@ describe('GET /marine-licence', () => {
               consent: 'yes',
               reason: 'Test public register reason'
             },
-            preferredDates: {
-              start: preferredDates.start.toISOString(),
-              end: preferredDates.end.toISOString()
-            },
+            preferredDates,
             otherAuthorities: 'Test authority',
             projectBackground: 'Test project background',
             taskList: {

--- a/src/marine-licences/api/controllers/update-preferred-dates.integration.test.js
+++ b/src/marine-licences/api/controllers/update-preferred-dates.integration.test.js
@@ -9,6 +9,7 @@ describe('PATCH /marine-licence/preferred-dates - integration tests', async () =
   const contactId = '123e4567-e89b-12d3-a456-426614174000'
   const differentContactId = '987e6543-e21b-12d3-a456-426614174000'
   const marineLicenceId = new ObjectId()
+  const nextYear = String(new Date().getFullYear() + 1)
 
   test('successfully updates preferred dates', async () => {
     const marineLicence = createCompleteMarineLicence({
@@ -21,8 +22,8 @@ describe('PATCH /marine-licence/preferred-dates - integration tests', async () =
 
     const payload = {
       id: marineLicenceId.toString(),
-      start: { month: '06', year: '2026' },
-      end: { month: '12', year: '2026' }
+      start: { month: '06', year: nextYear },
+      end: { month: '12', year: nextYear }
     }
 
     const { statusCode, body } = await makePatchRequest({
@@ -40,8 +41,8 @@ describe('PATCH /marine-licence/preferred-dates - integration tests', async () =
       .findOne({ _id: marineLicenceId })
 
     expect(updatedLicence.preferredDates).toEqual({
-      start: { month: '06', year: '2026' },
-      end: { month: '12', year: '2026' }
+      start: { month: '06', year: nextYear },
+      end: { month: '12', year: nextYear }
     })
   })
 
@@ -50,8 +51,8 @@ describe('PATCH /marine-licence/preferred-dates - integration tests', async () =
 
     const payload = {
       id: nonExistentId.toString(),
-      start: { month: '06', year: '2026' },
-      end: { month: '12', year: '2026' }
+      start: { month: '06', year: nextYear },
+      end: { month: '12', year: nextYear }
     }
 
     const { statusCode, body } = await makePatchRequest({
@@ -76,8 +77,8 @@ describe('PATCH /marine-licence/preferred-dates - integration tests', async () =
 
     const payload = {
       id: marineLicenceId.toString(),
-      start: { month: '06', year: '2026' },
-      end: { month: '12', year: '2026' }
+      start: { month: '06', year: nextYear },
+      end: { month: '12', year: nextYear }
     }
 
     const { statusCode, body } = await makePatchRequest({
@@ -102,7 +103,7 @@ describe('PATCH /marine-licence/preferred-dates - integration tests', async () =
 
     const payload = {
       id: marineLicenceId.toString(),
-      end: { month: '12', year: '2026' }
+      end: { month: '12', year: nextYear }
     }
 
     const { statusCode, body } = await makePatchRequest({
@@ -127,8 +128,8 @@ describe('PATCH /marine-licence/preferred-dates - integration tests', async () =
 
     const payload = {
       id: marineLicenceId.toString(),
-      start: { month: '08', year: '2026' },
-      end: { month: '07', year: '2026' }
+      start: { month: '08', year: nextYear },
+      end: { month: '07', year: nextYear }
     }
 
     const { statusCode, body } = await makePatchRequest({

--- a/src/marine-licences/api/controllers/update-preferred-dates.integration.test.js
+++ b/src/marine-licences/api/controllers/update-preferred-dates.integration.test.js
@@ -3,6 +3,7 @@ import { makePatchRequest } from '../../../../tests/server-requests.js'
 import { createCompleteMarineLicence } from '../../../../tests/test.fixture.js'
 import { ObjectId } from 'mongodb'
 import { collectionMarineLicences } from '../../../shared/common/constants/db-collections.js'
+import { vi } from 'vitest'
 
 describe('PATCH /marine-licence/preferred-dates - integration tests', async () => {
   const getServer = await setupTestServer()
@@ -115,6 +116,43 @@ describe('PATCH /marine-licence/preferred-dates - integration tests', async () =
 
     expect(statusCode).toBe(400)
     expect(body.message).toContain('PREFERRED_START_DATE_REQUIRED')
+  })
+
+  describe('when start date is in the past', () => {
+    beforeEach(() => {
+      vi.useFakeTimers({ toFake: ['Date'] })
+      vi.setSystemTime(new Date('2026-06-15T12:00:00.000Z'))
+    })
+
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    test('returns 400', async () => {
+      const marineLicence = createCompleteMarineLicence({
+        _id: marineLicenceId,
+        contactId
+      })
+      await globalThis.mockMongo
+        .collection(collectionMarineLicences)
+        .insertOne(marineLicence)
+
+      const payload = {
+        id: marineLicenceId.toString(),
+        start: { month: '01', year: '2026' },
+        end: { month: '12', year: '2027' }
+      }
+
+      const { statusCode, body } = await makePatchRequest({
+        server: getServer(),
+        url: '/marine-licence/preferred-dates',
+        contactId,
+        payload
+      })
+
+      expect(statusCode).toBe(400)
+      expect(body.message).toContain('PREFERRED_START_DATE_TODAY_OR_FUTURE')
+    })
   })
 
   test('returns 400 when end date is before start date', async () => {

--- a/src/marine-licences/api/controllers/update-preferred-dates.integration.test.js
+++ b/src/marine-licences/api/controllers/update-preferred-dates.integration.test.js
@@ -21,8 +21,8 @@ describe('PATCH /marine-licence/preferred-dates - integration tests', async () =
 
     const payload = {
       id: marineLicenceId.toString(),
-      start: '2026-06-01',
-      end: '2026-12-01'
+      start: { month: '06', year: '2026' },
+      end: { month: '12', year: '2026' }
     }
 
     const { statusCode, body } = await makePatchRequest({
@@ -39,8 +39,10 @@ describe('PATCH /marine-licence/preferred-dates - integration tests', async () =
       .collection(collectionMarineLicences)
       .findOne({ _id: marineLicenceId })
 
-    expect(updatedLicence.preferredDates.start).toEqual(new Date('2026-06-01'))
-    expect(updatedLicence.preferredDates.end).toEqual(new Date('2026-12-01'))
+    expect(updatedLicence.preferredDates).toEqual({
+      start: { month: '06', year: '2026' },
+      end: { month: '12', year: '2026' }
+    })
   })
 
   test('returns 404 when marine licence does not exist', async () => {
@@ -48,8 +50,8 @@ describe('PATCH /marine-licence/preferred-dates - integration tests', async () =
 
     const payload = {
       id: nonExistentId.toString(),
-      start: '2026-06-01',
-      end: '2026-12-01'
+      start: { month: '06', year: '2026' },
+      end: { month: '12', year: '2026' }
     }
 
     const { statusCode, body } = await makePatchRequest({
@@ -74,8 +76,8 @@ describe('PATCH /marine-licence/preferred-dates - integration tests', async () =
 
     const payload = {
       id: marineLicenceId.toString(),
-      start: '2026-06-01',
-      end: '2026-12-01'
+      start: { month: '06', year: '2026' },
+      end: { month: '12', year: '2026' }
     }
 
     const { statusCode, body } = await makePatchRequest({
@@ -100,7 +102,7 @@ describe('PATCH /marine-licence/preferred-dates - integration tests', async () =
 
     const payload = {
       id: marineLicenceId.toString(),
-      end: '2026-12-01'
+      end: { month: '12', year: '2026' }
     }
 
     const { statusCode, body } = await makePatchRequest({
@@ -125,8 +127,8 @@ describe('PATCH /marine-licence/preferred-dates - integration tests', async () =
 
     const payload = {
       id: marineLicenceId.toString(),
-      start: '2026-08-01',
-      end: '2026-07-01'
+      start: { month: '08', year: '2026' },
+      end: { month: '07', year: '2026' }
     }
 
     const { statusCode, body } = await makePatchRequest({

--- a/src/marine-licences/api/controllers/update-preferred-dates.integration.test.js
+++ b/src/marine-licences/api/controllers/update-preferred-dates.integration.test.js
@@ -1,0 +1,142 @@
+import { setupTestServer } from '../../../../tests/test-server.js'
+import { makePatchRequest } from '../../../../tests/server-requests.js'
+import { createCompleteMarineLicence } from '../../../../tests/test.fixture.js'
+import { ObjectId } from 'mongodb'
+import { collectionMarineLicences } from '../../../shared/common/constants/db-collections.js'
+
+describe('PATCH /marine-licence/preferred-dates - integration tests', async () => {
+  const getServer = await setupTestServer()
+  const contactId = '123e4567-e89b-12d3-a456-426614174000'
+  const differentContactId = '987e6543-e21b-12d3-a456-426614174000'
+  const marineLicenceId = new ObjectId()
+
+  test('successfully updates preferred dates', async () => {
+    const marineLicence = createCompleteMarineLicence({
+      _id: marineLicenceId,
+      contactId
+    })
+    await globalThis.mockMongo
+      .collection(collectionMarineLicences)
+      .insertOne(marineLicence)
+
+    const payload = {
+      id: marineLicenceId.toString(),
+      start: '2026-06-01',
+      end: '2026-12-01'
+    }
+
+    const { statusCode, body } = await makePatchRequest({
+      server: getServer(),
+      url: '/marine-licence/preferred-dates',
+      contactId,
+      payload
+    })
+
+    expect(statusCode).toBe(200)
+    expect(body).toEqual({ message: 'success' })
+
+    const updatedLicence = await globalThis.mockMongo
+      .collection(collectionMarineLicences)
+      .findOne({ _id: marineLicenceId })
+
+    expect(updatedLicence.preferredDates.start).toEqual(new Date('2026-06-01'))
+    expect(updatedLicence.preferredDates.end).toEqual(new Date('2026-12-01'))
+  })
+
+  test('returns 404 when marine licence does not exist', async () => {
+    const nonExistentId = new ObjectId()
+
+    const payload = {
+      id: nonExistentId.toString(),
+      start: '2026-06-01',
+      end: '2026-12-01'
+    }
+
+    const { statusCode, body } = await makePatchRequest({
+      server: getServer(),
+      url: '/marine-licence/preferred-dates',
+      contactId,
+      payload
+    })
+
+    expect(statusCode).toBe(404)
+    expect(body.message).toBe('Not Found')
+  })
+
+  test('returns 403 when attempting to update another users marine licence', async () => {
+    const marineLicence = createCompleteMarineLicence({
+      _id: marineLicenceId,
+      contactId
+    })
+    await globalThis.mockMongo
+      .collection(collectionMarineLicences)
+      .insertOne(marineLicence)
+
+    const payload = {
+      id: marineLicenceId.toString(),
+      start: '2026-06-01',
+      end: '2026-12-01'
+    }
+
+    const { statusCode, body } = await makePatchRequest({
+      server: getServer(),
+      url: '/marine-licence/preferred-dates',
+      contactId: differentContactId,
+      payload
+    })
+
+    expect(statusCode).toBe(403)
+    expect(body.message).toBe('Not authorised to request this resource')
+  })
+
+  test('returns 400 when start date is missing', async () => {
+    const marineLicence = createCompleteMarineLicence({
+      _id: marineLicenceId,
+      contactId
+    })
+    await globalThis.mockMongo
+      .collection(collectionMarineLicences)
+      .insertOne(marineLicence)
+
+    const payload = {
+      id: marineLicenceId.toString(),
+      end: '2026-12-01'
+    }
+
+    const { statusCode, body } = await makePatchRequest({
+      server: getServer(),
+      url: '/marine-licence/preferred-dates',
+      contactId,
+      payload
+    })
+
+    expect(statusCode).toBe(400)
+    expect(body.message).toContain('PREFERRED_START_DATE_REQUIRED')
+  })
+
+  test('returns 400 when end date is before start date', async () => {
+    const marineLicence = createCompleteMarineLicence({
+      _id: marineLicenceId,
+      contactId
+    })
+    await globalThis.mockMongo
+      .collection(collectionMarineLicences)
+      .insertOne(marineLicence)
+
+    const payload = {
+      id: marineLicenceId.toString(),
+      start: '2026-08-01',
+      end: '2026-07-01'
+    }
+
+    const { statusCode, body } = await makePatchRequest({
+      server: getServer(),
+      url: '/marine-licence/preferred-dates',
+      contactId,
+      payload
+    })
+
+    expect(statusCode).toBe(400)
+    expect(body.message).toContain('PREFERRED_END_DATE_BEFORE_START_DATE')
+  })
+})

--- a/src/marine-licences/api/controllers/update-preferred-dates.js
+++ b/src/marine-licences/api/controllers/update-preferred-dates.js
@@ -1,0 +1,49 @@
+import Boom from '@hapi/boom'
+import { preferredDates } from '../../models/preferred-dates.js'
+import { StatusCodes } from 'http-status-codes'
+import { ObjectId } from 'mongodb'
+import { collectionMarineLicences } from '../../../shared/common/constants/db-collections.js'
+import { authorizeOwnership } from '../../../shared/helpers/authorize-ownership.js'
+
+export const updatePreferredDatesController = {
+  options: {
+    payload: {
+      parse: true,
+      output: 'data'
+    },
+    pre: [{ method: authorizeOwnership(collectionMarineLicences) }],
+    validate: {
+      query: false,
+      payload: preferredDates
+    }
+  },
+  handler: async (request, h) => {
+    try {
+      const { payload, db } = request
+      const { start, end, id, updatedAt, updatedBy } = payload
+      const result = await db.collection(collectionMarineLicences).updateOne(
+        { _id: ObjectId.createFromHexString(id) },
+        {
+          $set: {
+            preferredDates: { start, end },
+            updatedAt,
+            updatedBy
+          }
+        }
+      )
+      if (result.matchedCount === 0) {
+        throw Boom.notFound('Marine licence not found')
+      }
+      return h
+        .response({
+          message: 'success'
+        })
+        .code(StatusCodes.OK)
+    } catch (error) {
+      if (error.isBoom) {
+        throw error
+      }
+      throw Boom.internal(`Error updating preferred dates: ${error.message}`)
+    }
+  }
+}

--- a/src/marine-licences/api/controllers/update-preferred-dates.test.js
+++ b/src/marine-licences/api/controllers/update-preferred-dates.test.js
@@ -1,0 +1,123 @@
+import { vi } from 'vitest'
+import { ObjectId } from 'mongodb'
+import { updatePreferredDatesController } from './update-preferred-dates.js'
+
+describe('PATCH /marine-licence/preferred-dates', () => {
+  const payloadValidator =
+    updatePreferredDatesController.options.validate.payload
+  const mockAuditPayload = {
+    updatedAt: new Date('2026-05-21T12:00:00.000Z'),
+    updatedBy: 'user123'
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-05-21T12:00:00.000Z'))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('should fail if start is missing', () => {
+    const result = payloadValidator.validate({
+      end: '2026-12-01'
+    })
+    expect(result.error.message).toContain('PREFERRED_START_DATE_REQUIRED')
+  })
+
+  it('should fail if end is before start', () => {
+    const result = payloadValidator.validate({
+      id: new ObjectId().toHexString(),
+      start: '2026-08-01',
+      end: '2026-07-01'
+    })
+    expect(result.error.message).toContain(
+      'PREFERRED_END_DATE_BEFORE_START_DATE'
+    )
+  })
+
+  it('should update marine licence with preferred dates', async () => {
+    const { mockMongo, mockHandler } = global
+    const mockPayload = {
+      id: new ObjectId().toHexString(),
+      start: '2026-05-21',
+      end: '2026-12-01',
+      ...mockAuditPayload
+    }
+
+    const mockUpdateOne = vi.fn().mockResolvedValueOnce({ matchedCount: 1 })
+    vi.spyOn(mockMongo, 'collection').mockImplementation(function () {
+      return { updateOne: mockUpdateOne }
+    })
+
+    await updatePreferredDatesController.handler(
+      { db: mockMongo, payload: mockPayload },
+      mockHandler
+    )
+
+    expect(mockHandler.response).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'success' })
+    )
+    expect(mockMongo.collection).toHaveBeenCalledWith('marine-licences')
+    expect(mockUpdateOne).toHaveBeenCalledWith(
+      { _id: ObjectId.createFromHexString(mockPayload.id) },
+      {
+        $set: {
+          preferredDates: {
+            start: mockPayload.start,
+            end: mockPayload.end
+          },
+          ...mockAuditPayload
+        }
+      }
+    )
+  })
+
+  it('should return an error message if the database operation fails', async () => {
+    const { mockMongo, mockHandler } = global
+    const mockPayload = {
+      id: new ObjectId().toHexString(),
+      start: '2026-05-21',
+      end: '2026-12-01',
+      ...mockAuditPayload
+    }
+
+    const mockError = 'Database failed'
+    vi.spyOn(mockMongo, 'collection').mockImplementation(function () {
+      return {
+        updateOne: vi.fn().mockRejectedValueOnce(new Error(mockError))
+      }
+    })
+
+    await expect(() =>
+      updatePreferredDatesController.handler(
+        { db: mockMongo, payload: mockPayload },
+        mockHandler
+      )
+    ).rejects.toThrow(`Error updating preferred dates: ${mockError}`)
+  })
+
+  it('should return a 404 if id is not correct', async () => {
+    const { mockMongo, mockHandler } = global
+    const mockPayload = {
+      id: new ObjectId().toHexString(),
+      start: '2026-05-21',
+      end: '2026-12-01',
+      ...mockAuditPayload
+    }
+
+    vi.spyOn(mockMongo, 'collection').mockImplementation(function () {
+      return {
+        updateOne: vi.fn().mockResolvedValueOnce({ matchedCount: 0 })
+      }
+    })
+
+    await expect(() =>
+      updatePreferredDatesController.handler(
+        { db: mockMongo, payload: mockPayload },
+        mockHandler
+      )
+    ).rejects.toThrow('Marine licence not found')
+  })
+})

--- a/src/marine-licences/api/controllers/update-preferred-dates.test.js
+++ b/src/marine-licences/api/controllers/update-preferred-dates.test.js
@@ -3,8 +3,6 @@ import { ObjectId } from 'mongodb'
 import { updatePreferredDatesController } from './update-preferred-dates.js'
 
 describe('PATCH /marine-licence/preferred-dates', () => {
-  const payloadValidator =
-    updatePreferredDatesController.options.validate.payload
   const mockAuditPayload = {
     updatedAt: new Date('2026-05-21T12:00:00.000Z'),
     updatedBy: 'user123'
@@ -19,30 +17,12 @@ describe('PATCH /marine-licence/preferred-dates', () => {
     vi.useRealTimers()
   })
 
-  it('should fail if start is missing', () => {
-    const result = payloadValidator.validate({
-      end: '2026-12-01'
-    })
-    expect(result.error.message).toContain('PREFERRED_START_DATE_REQUIRED')
-  })
-
-  it('should fail if end is before start', () => {
-    const result = payloadValidator.validate({
-      id: new ObjectId().toHexString(),
-      start: '2026-08-01',
-      end: '2026-07-01'
-    })
-    expect(result.error.message).toContain(
-      'PREFERRED_END_DATE_BEFORE_START_DATE'
-    )
-  })
-
   it('should update marine licence with preferred dates', async () => {
     const { mockMongo, mockHandler } = global
     const mockPayload = {
       id: new ObjectId().toHexString(),
-      start: '2026-05-21',
-      end: '2026-12-01',
+      start: { month: '05', year: '2026' },
+      end: { month: '12', year: '2026' },
       ...mockAuditPayload
     }
 
@@ -78,8 +58,8 @@ describe('PATCH /marine-licence/preferred-dates', () => {
     const { mockMongo, mockHandler } = global
     const mockPayload = {
       id: new ObjectId().toHexString(),
-      start: '2026-05-21',
-      end: '2026-12-01',
+      start: { month: '05', year: '2026' },
+      end: { month: '12', year: '2026' },
       ...mockAuditPayload
     }
 
@@ -102,8 +82,8 @@ describe('PATCH /marine-licence/preferred-dates', () => {
     const { mockMongo, mockHandler } = global
     const mockPayload = {
       id: new ObjectId().toHexString(),
-      start: '2026-05-21',
-      end: '2026-12-01',
+      start: { month: '05', year: '2026' },
+      end: { month: '12', year: '2026' },
       ...mockAuditPayload
     }
 

--- a/src/marine-licences/api/controllers/update-preferred-dates.test.js
+++ b/src/marine-licences/api/controllers/update-preferred-dates.test.js
@@ -8,15 +8,6 @@ describe('PATCH /marine-licence/preferred-dates', () => {
     updatedBy: 'user123'
   }
 
-  beforeEach(() => {
-    vi.useFakeTimers()
-    vi.setSystemTime(new Date('2026-05-21T12:00:00.000Z'))
-  })
-
-  afterEach(() => {
-    vi.useRealTimers()
-  })
-
   it('should update marine licence with preferred dates', async () => {
     const { mockMongo, mockHandler } = global
     const mockPayload = {

--- a/src/marine-licences/api/helpers/createTaskList.js
+++ b/src/marine-licences/api/helpers/createTaskList.js
@@ -161,6 +161,7 @@ export const createTaskList = (marineLicence, isCitizen = false) => {
     otherAuthorities: (value) => (value ? COMPLETED : INCOMPLETE),
     projectBackground: (value) => (value ? COMPLETED : INCOMPLETE),
     siteDetails: (value) => getSiteDetailsStatus(value),
+    preferredDates: (value) => (value ? COMPLETED : INCOMPLETE),
     publicRegister: (value) => (value ? COMPLETED : INCOMPLETE)
   }
 

--- a/src/marine-licences/api/helpers/createTaskList.test.js
+++ b/src/marine-licences/api/helpers/createTaskList.test.js
@@ -36,6 +36,7 @@ describe('createTaskList', () => {
       siteDetails: [mockCompleteSite],
       specialLegalPowers: 'Some powers',
       otherAuthorities: 'Some authorities',
+      preferredDates: { start: '2026-01-01', end: '2026-12-31' },
       projectBackground: 'Some background',
       publicRegister: 'Public Register Info'
     }
@@ -45,6 +46,7 @@ describe('createTaskList', () => {
       siteDetails: COMPLETED,
       specialLegalPowers: COMPLETED,
       otherAuthorities: COMPLETED,
+      preferredDates: COMPLETED,
       projectBackground: COMPLETED,
       publicRegister: COMPLETED
     })
@@ -57,6 +59,7 @@ describe('createTaskList', () => {
       otherAuthorities: 'Some authorities',
       projectBackground: 'Some background',
       siteDetails: [mockFileUploadSite],
+      preferredDates: { start: '2026-01-01', end: '2026-12-31' },
       publicRegister: 'Public Register Info'
     }
 
@@ -65,6 +68,7 @@ describe('createTaskList', () => {
       publicRegister: COMPLETED,
       siteDetails: IN_PROGRESS,
       otherAuthorities: COMPLETED,
+      preferredDates: COMPLETED,
       projectBackground: COMPLETED
     })
   })
@@ -78,7 +82,8 @@ describe('createTaskList', () => {
       specialLegalPowers: 'Some powers',
       otherAuthorities: 'Some authorities',
       siteDetails: [siteWithoutSiteName],
-      projectBackground: 'Test project background'
+      projectBackground: 'Test project background',
+      preferredDates: { start: '2026-01-01', end: '2026-12-31' }
     }
 
     expect(createTaskList(marineLicence)).toEqual({
@@ -86,6 +91,7 @@ describe('createTaskList', () => {
       siteDetails: IN_PROGRESS,
       specialLegalPowers: COMPLETED,
       otherAuthorities: COMPLETED,
+      preferredDates: COMPLETED,
       projectBackground: COMPLETED,
       publicRegister: INCOMPLETE
     })
@@ -331,6 +337,7 @@ describe('createTaskList', () => {
       projectName: INCOMPLETE,
       specialLegalPowers: INCOMPLETE,
       otherAuthorities: INCOMPLETE,
+      preferredDates: INCOMPLETE,
       projectBackground: INCOMPLETE,
       publicRegister: INCOMPLETE,
       siteDetails: INCOMPLETE
@@ -343,6 +350,7 @@ describe('createTaskList', () => {
       specialLegalPowers: 'some powers',
       publicRegister: 'Public Register Info',
       otherAuthorities: 'Some authorities',
+      preferredDates: { start: '2026-01-01', end: '2026-12-31' },
       projectBackground: 'Some background',
       siteDetails: [mockFileUploadSite]
     }
@@ -353,6 +361,7 @@ describe('createTaskList', () => {
       projectName: COMPLETED,
       specialLegalPowers: COMPLETED,
       otherAuthorities: COMPLETED,
+      preferredDates: COMPLETED,
       projectBackground: COMPLETED,
       publicRegister: COMPLETED,
       siteDetails: IN_PROGRESS

--- a/src/marine-licences/api/helpers/createTaskList.test.js
+++ b/src/marine-licences/api/helpers/createTaskList.test.js
@@ -36,7 +36,10 @@ describe('createTaskList', () => {
       siteDetails: [mockCompleteSite],
       specialLegalPowers: 'Some powers',
       otherAuthorities: 'Some authorities',
-      preferredDates: { start: '2026-01-01', end: '2026-12-31' },
+      preferredDates: {
+        start: { month: '01', year: '2026' },
+        end: { month: '12', year: '2026' }
+      },
       projectBackground: 'Some background',
       publicRegister: 'Public Register Info'
     }
@@ -59,7 +62,10 @@ describe('createTaskList', () => {
       otherAuthorities: 'Some authorities',
       projectBackground: 'Some background',
       siteDetails: [mockFileUploadSite],
-      preferredDates: { start: '2026-01-01', end: '2026-12-31' },
+      preferredDates: {
+        start: { month: '01', year: '2026' },
+        end: { month: '12', year: '2026' }
+      },
       publicRegister: 'Public Register Info'
     }
 
@@ -83,7 +89,10 @@ describe('createTaskList', () => {
       otherAuthorities: 'Some authorities',
       siteDetails: [siteWithoutSiteName],
       projectBackground: 'Test project background',
-      preferredDates: { start: '2026-01-01', end: '2026-12-31' }
+      preferredDates: {
+        start: { month: '01', year: '2026' },
+        end: { month: '12', year: '2026' }
+      }
     }
 
     expect(createTaskList(marineLicence)).toEqual({
@@ -350,7 +359,10 @@ describe('createTaskList', () => {
       specialLegalPowers: 'some powers',
       publicRegister: 'Public Register Info',
       otherAuthorities: 'Some authorities',
-      preferredDates: { start: '2026-01-01', end: '2026-12-31' },
+      preferredDates: {
+        start: { month: '01', year: '2026' },
+        end: { month: '12', year: '2026' }
+      },
       projectBackground: 'Some background',
       siteDetails: [mockFileUploadSite]
     }

--- a/src/marine-licences/api/index.js
+++ b/src/marine-licences/api/index.js
@@ -5,6 +5,7 @@ import { deleteMarineLicenceController } from './controllers/delete-marine-licen
 import { submitMarineLicenceController } from './controllers/submit-marine-licence.js'
 import { updateSpecialLegalPowersController } from './controllers/update-special-legal-powers.js'
 import { updatePublicRegisterController } from './controllers/update-public-register.js'
+import { updatePreferredDatesController } from './controllers/update-preferred-dates.js'
 import { updateOtherAuthoritiesController } from './controllers/update-other-authorities.js'
 import { updateProjectBackgroundController } from './controllers/update-project-background.js'
 import { updateSiteDetailsController } from './controllers/update-site-details.js'
@@ -82,5 +83,10 @@ export const marineLicences = [
     method: 'PATCH',
     path: '/marine-licence/public-register',
     ...updatePublicRegisterController
+  },
+  {
+    method: 'PATCH',
+    path: '/marine-licence/preferred-dates',
+    ...updatePreferredDatesController
   }
 ]

--- a/src/marine-licences/models/preferred-dates.js
+++ b/src/marine-licences/models/preferred-dates.js
@@ -7,13 +7,14 @@ const MAX_YEAR = MIN_YEAR + MAX_YEAR_OFFSET
 
 const MONTH_PATTERN = /^(0?[1-9]|1[0-2])$/
 const YEAR_PATTERN = /^\d{4}$/
+const MAX_MONTH = 12
 
 const toMonthValue = ({ month, year }) =>
-  Number(year) * 12 + (Number(month) - 1)
+  Number(year) * MAX_MONTH + (Number(month) - 1)
 
 const currentMonthValue = () => {
   const now = new Date()
-  return now.getFullYear() * 12 + now.getMonth()
+  return now.getFullYear() * MAX_MONTH + now.getMonth()
 }
 
 const monthSchema = (errorPrefix) =>

--- a/src/marine-licences/models/preferred-dates.js
+++ b/src/marine-licences/models/preferred-dates.js
@@ -1,0 +1,48 @@
+import joi from 'joi'
+import { marineLicenceId } from './shared-models.js'
+
+const MIN_YEAR = new Date().getFullYear()
+const MAX_YEAR_OFFSET = 20
+const MAX_YEAR = MIN_YEAR + MAX_YEAR_OFFSET
+
+const MAX_DAYS_IN_MONTH = 31
+const MAX_MONTHS_IN_YEAR = 12
+
+const MAX_DATE = new Date(MAX_YEAR, MAX_MONTHS_IN_YEAR, MAX_DAYS_IN_MONTH)
+
+const startOfToday = () => {
+  const now = new Date()
+  return new Date(
+    Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate())
+  )
+}
+
+const isTodayOrLater = (value, helpers) => {
+  const date = new Date(
+    Date.UTC(value.getUTCFullYear(), value.getUTCMonth(), value.getUTCDate())
+  )
+
+  if (date < startOfToday()) {
+    return helpers.error('date.min')
+  }
+
+  return value
+}
+
+export const preferredDatesRangeSchema = joi.object({
+  start: joi.date().required().custom(isTodayOrLater).max(MAX_DATE).messages({
+    'any.required': 'PREFERRED_START_DATE_REQUIRED',
+    'date.base': 'PREFERRED_START_DATE_INVALID',
+    'date.min': 'PREFERRED_START_DATE_TODAY_OR_FUTURE',
+    'date.max': 'PREFERRED_START_DATE_INVALID'
+  }),
+  end: joi.date().required().min(joi.ref('start')).max(MAX_DATE).messages({
+    'any.required': 'PREFERRED_END_DATE_REQUIRED',
+    'date.base': 'PREFERRED_END_DATE_INVALID',
+    'date.greater': 'PREFERRED_END_DATE_BEFORE_START_DATE',
+    'date.min': 'PREFERRED_END_DATE_BEFORE_START_DATE',
+    'date.max': 'PREFERRED_END_DATE_INVALID'
+  })
+})
+
+export const preferredDates = preferredDatesRangeSchema.append(marineLicenceId)

--- a/src/marine-licences/models/preferred-dates.js
+++ b/src/marine-licences/models/preferred-dates.js
@@ -5,44 +5,88 @@ const MIN_YEAR = new Date().getFullYear()
 const MAX_YEAR_OFFSET = 20
 const MAX_YEAR = MIN_YEAR + MAX_YEAR_OFFSET
 
-const MAX_DAYS_IN_MONTH = 31
-const MAX_MONTHS_IN_YEAR = 12
+const MONTH_PATTERN = /^(0?[1-9]|1[0-2])$/
+const YEAR_PATTERN = /^\d{4}$/
 
-const MAX_DATE = new Date(MAX_YEAR, MAX_MONTHS_IN_YEAR, MAX_DAYS_IN_MONTH)
+const toMonthValue = ({ month, year }) =>
+  Number(year) * 12 + (Number(month) - 1)
 
-const startOfToday = () => {
+const currentMonthValue = () => {
   const now = new Date()
-  return new Date(
-    Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate())
-  )
+  return now.getFullYear() * 12 + now.getMonth()
 }
 
-const isTodayOrLater = (value, helpers) => {
-  const date = new Date(
-    Date.UTC(value.getUTCFullYear(), value.getUTCMonth(), value.getUTCDate())
-  )
+const monthSchema = (errorPrefix) =>
+  joi
+    .string()
+    .pattern(MONTH_PATTERN)
+    .required()
+    .messages({
+      'any.required': `${errorPrefix}_MONTH_REQUIRED`,
+      'string.empty': `${errorPrefix}_MONTH_REQUIRED`,
+      'string.pattern.base': `${errorPrefix}_MONTH_INVALID`
+    })
 
-  if (date < startOfToday()) {
-    return helpers.error('date.min')
-  }
+const yearSchema = (errorPrefix) =>
+  joi
+    .string()
+    .pattern(YEAR_PATTERN)
+    .required()
+    .messages({
+      'any.required': `${errorPrefix}_YEAR_REQUIRED`,
+      'string.empty': `${errorPrefix}_YEAR_REQUIRED`,
+      'string.pattern.base': `${errorPrefix}_YEAR_INVALID`
+    })
 
-  return value
-}
+const preferredDatePartSchema = (
+  errorPrefix,
+  { validateTodayOrLater = false } = {}
+) =>
+  joi
+    .object({
+      month: monthSchema(errorPrefix),
+      year: yearSchema(errorPrefix)
+    })
+    .custom((value, helpers) => {
+      const year = Number(value.year)
 
-export const preferredDatesRangeSchema = joi.object({
-  start: joi.date().required().custom(isTodayOrLater).max(MAX_DATE).messages({
-    'any.required': 'PREFERRED_START_DATE_REQUIRED',
-    'date.base': 'PREFERRED_START_DATE_INVALID',
-    'date.min': 'PREFERRED_START_DATE_TODAY_OR_FUTURE',
-    'date.max': 'PREFERRED_START_DATE_INVALID'
-  }),
-  end: joi.date().required().min(joi.ref('start')).max(MAX_DATE).messages({
-    'any.required': 'PREFERRED_END_DATE_REQUIRED',
-    'date.base': 'PREFERRED_END_DATE_INVALID',
-    'date.greater': 'PREFERRED_END_DATE_BEFORE_START_DATE',
-    'date.min': 'PREFERRED_END_DATE_BEFORE_START_DATE',
-    'date.max': 'PREFERRED_END_DATE_INVALID'
+      if (year < MIN_YEAR || year > MAX_YEAR) {
+        return helpers.error('number.range')
+      }
+
+      if (validateTodayOrLater && toMonthValue(value) < currentMonthValue()) {
+        return helpers.error('date.min')
+      }
+
+      return value
+    })
+    .messages({
+      'number.range': `${errorPrefix}_YEAR_INVALID`,
+      'date.min': `${errorPrefix}_DATE_TODAY_OR_FUTURE`
+    })
+
+export const preferredDatesRangeSchema = joi
+  .object({
+    start: preferredDatePartSchema('PREFERRED_START', {
+      validateTodayOrLater: true
+    })
+      .required()
+      .messages({
+        'any.required': 'PREFERRED_START_DATE_REQUIRED'
+      }),
+    end: preferredDatePartSchema('PREFERRED_END').required().messages({
+      'any.required': 'PREFERRED_END_DATE_REQUIRED'
+    })
   })
-})
+  .custom((value, helpers) => {
+    if (toMonthValue(value.end) < toMonthValue(value.start)) {
+      return helpers.error('date.min')
+    }
+
+    return value
+  })
+  .messages({
+    'date.min': 'PREFERRED_END_DATE_BEFORE_START_DATE'
+  })
 
 export const preferredDates = preferredDatesRangeSchema.append(marineLicenceId)

--- a/src/marine-licences/models/preferred-dates.js
+++ b/src/marine-licences/models/preferred-dates.js
@@ -1,7 +1,7 @@
 import joi from 'joi'
 import { marineLicenceId } from './shared-models.js'
 
-const MIN_YEAR = new Date().getFullYear()
+const getMinYear = () => new Date().getFullYear()
 
 const MONTH_PATTERN = /^(0?[1-9]|1[0-2])$/
 const YEAR_PATTERN = /^\d{4}$/
@@ -49,7 +49,7 @@ const preferredDatePartSchema = (
     .custom((value, helpers) => {
       const year = Number(value.year)
 
-      if (year < MIN_YEAR) {
+      if (year < getMinYear()) {
         return helpers.error('number.range')
       }
 

--- a/src/marine-licences/models/preferred-dates.js
+++ b/src/marine-licences/models/preferred-dates.js
@@ -2,8 +2,6 @@ import joi from 'joi'
 import { marineLicenceId } from './shared-models.js'
 
 const MIN_YEAR = new Date().getFullYear()
-const MAX_YEAR_OFFSET = 20
-const MAX_YEAR = MIN_YEAR + MAX_YEAR_OFFSET
 
 const MONTH_PATTERN = /^(0?[1-9]|1[0-2])$/
 const YEAR_PATTERN = /^\d{4}$/
@@ -51,7 +49,7 @@ const preferredDatePartSchema = (
     .custom((value, helpers) => {
       const year = Number(value.year)
 
-      if (year < MIN_YEAR || year > MAX_YEAR) {
+      if (year < MIN_YEAR) {
         return helpers.error('number.range')
       }
 

--- a/src/marine-licences/models/preferred-dates.js
+++ b/src/marine-licences/models/preferred-dates.js
@@ -5,14 +5,21 @@ const getMinYear = () => new Date().getFullYear()
 
 const MONTH_PATTERN = /^(0?[1-9]|1[0-2])$/
 const YEAR_PATTERN = /^\d{4}$/
-const MAX_MONTH = 12
 
-const toMonthValue = ({ month, year }) =>
-  Number(year) * MAX_MONTH + (Number(month) - 1)
+const isSameYearAndEndMonthBefore = (start, end) =>
+  Number(end.year) === Number(start.year) &&
+  Number(end.month) < Number(start.month)
 
-const currentMonthValue = () => {
+const isEndBeforeStart = (start, end) =>
+  Number(end.year) < Number(start.year) ||
+  isSameYearAndEndMonthBefore(start, end)
+
+const isBeforeCurrentMonth = ({ month, year }) => {
   const now = new Date()
-  return now.getFullYear() * MAX_MONTH + now.getMonth()
+  return (
+    Number(year) < now.getFullYear() ||
+    (Number(year) === now.getFullYear() && Number(month) - 1 < now.getMonth())
+  )
 }
 
 const monthSchema = (errorPrefix) =>
@@ -53,7 +60,7 @@ const preferredDatePartSchema = (
         return helpers.error('number.range')
       }
 
-      if (validateTodayOrLater && toMonthValue(value) < currentMonthValue()) {
+      if (validateTodayOrLater && isBeforeCurrentMonth(value)) {
         return helpers.error('date.min')
       }
 
@@ -78,7 +85,7 @@ export const preferredDatesRangeSchema = joi
     })
   })
   .custom((value, helpers) => {
-    if (toMonthValue(value.end) < toMonthValue(value.start)) {
+    if (isEndBeforeStart(value.start, value.end)) {
       return helpers.error('date.min')
     }
 

--- a/src/marine-licences/models/preferred-dates.test.js
+++ b/src/marine-licences/models/preferred-dates.test.js
@@ -12,12 +12,20 @@ describe('preferredDatesRangeSchema', () => {
   })
 
   const validPayload = {
-    start: '2026-05-21',
-    end: '2026-12-01'
+    start: { month: '05', year: '2026' },
+    end: { month: '12', year: '2026' }
   }
 
   test('should pass with valid start and end dates', () => {
     const { error } = preferredDatesRangeSchema.validate(validPayload)
+    expect(error).toBeUndefined()
+  })
+
+  test('should accept single digit months', () => {
+    const { error } = preferredDatesRangeSchema.validate({
+      start: { month: '5', year: '2026' },
+      end: { month: '9', year: '2026' }
+    })
     expect(error).toBeUndefined()
   })
 
@@ -35,25 +43,25 @@ describe('preferredDatesRangeSchema', () => {
     expect(error.message).toContain('PREFERRED_END_DATE_REQUIRED')
   })
 
-  test('should fail when start date is invalid', () => {
+  test('should fail when start month is invalid', () => {
     const { error } = preferredDatesRangeSchema.validate({
-      start: 'not-a-date',
+      start: { month: '13', year: '2026' },
       end: validPayload.end
     })
-    expect(error.message).toContain('PREFERRED_START_DATE_INVALID')
+    expect(error.message).toContain('PREFERRED_START_MONTH_INVALID')
   })
 
-  test('should fail when end date is invalid', () => {
+  test('should fail when start year is not YYYY format', () => {
     const { error } = preferredDatesRangeSchema.validate({
-      start: validPayload.start,
-      end: 'not-a-date'
+      start: { month: '05', year: '26' },
+      end: validPayload.end
     })
-    expect(error.message).toContain('PREFERRED_END_DATE_INVALID')
+    expect(error.message).toContain('PREFERRED_START_YEAR_INVALID')
   })
 
-  test('should fail when start date is before today', () => {
+  test('should fail when start date is before current month', () => {
     const { error } = preferredDatesRangeSchema.validate({
-      start: '2026-05-20',
+      start: { month: '04', year: '2026' },
       end: validPayload.end
     })
     expect(error.message).toContain('PREFERRED_START_DATE_TODAY_OR_FUTURE')
@@ -61,16 +69,16 @@ describe('preferredDatesRangeSchema', () => {
 
   test('should fail when end date is before start date', () => {
     const { error } = preferredDatesRangeSchema.validate({
-      start: '2026-08-01',
-      end: '2026-07-01'
+      start: { month: '08', year: '2026' },
+      end: { month: '07', year: '2026' }
     })
     expect(error.message).toContain('PREFERRED_END_DATE_BEFORE_START_DATE')
   })
 
   test('should fail when end date is before start date across years', () => {
     const { error } = preferredDatesRangeSchema.validate({
-      start: '2027-02-01',
-      end: '2026-12-01'
+      start: { month: '02', year: '2027' },
+      end: { month: '12', year: '2026' }
     })
     expect(error.message).toContain('PREFERRED_END_DATE_BEFORE_START_DATE')
   })

--- a/src/marine-licences/models/preferred-dates.test.js
+++ b/src/marine-licences/models/preferred-dates.test.js
@@ -1,0 +1,77 @@
+import { vi } from 'vitest'
+import { preferredDatesRangeSchema } from './preferred-dates.js'
+
+describe('preferredDatesRangeSchema', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-05-21T12:00:00.000Z'))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  const validPayload = {
+    start: '2026-05-21',
+    end: '2026-12-01'
+  }
+
+  test('should pass with valid start and end dates', () => {
+    const { error } = preferredDatesRangeSchema.validate(validPayload)
+    expect(error).toBeUndefined()
+  })
+
+  test('should fail when start is missing', () => {
+    const { error } = preferredDatesRangeSchema.validate({
+      end: validPayload.end
+    })
+    expect(error.message).toContain('PREFERRED_START_DATE_REQUIRED')
+  })
+
+  test('should fail when end is missing', () => {
+    const { error } = preferredDatesRangeSchema.validate({
+      start: validPayload.start
+    })
+    expect(error.message).toContain('PREFERRED_END_DATE_REQUIRED')
+  })
+
+  test('should fail when start date is invalid', () => {
+    const { error } = preferredDatesRangeSchema.validate({
+      start: 'not-a-date',
+      end: validPayload.end
+    })
+    expect(error.message).toContain('PREFERRED_START_DATE_INVALID')
+  })
+
+  test('should fail when end date is invalid', () => {
+    const { error } = preferredDatesRangeSchema.validate({
+      start: validPayload.start,
+      end: 'not-a-date'
+    })
+    expect(error.message).toContain('PREFERRED_END_DATE_INVALID')
+  })
+
+  test('should fail when start date is before today', () => {
+    const { error } = preferredDatesRangeSchema.validate({
+      start: '2026-05-20',
+      end: validPayload.end
+    })
+    expect(error.message).toContain('PREFERRED_START_DATE_TODAY_OR_FUTURE')
+  })
+
+  test('should fail when end date is before start date', () => {
+    const { error } = preferredDatesRangeSchema.validate({
+      start: '2026-08-01',
+      end: '2026-07-01'
+    })
+    expect(error.message).toContain('PREFERRED_END_DATE_BEFORE_START_DATE')
+  })
+
+  test('should fail when end date is before start date across years', () => {
+    const { error } = preferredDatesRangeSchema.validate({
+      start: '2027-02-01',
+      end: '2026-12-01'
+    })
+    expect(error.message).toContain('PREFERRED_END_DATE_BEFORE_START_DATE')
+  })
+})

--- a/src/marine-licences/models/test-fixtures.js
+++ b/src/marine-licences/models/test-fixtures.js
@@ -2,8 +2,8 @@ import { MARINE_LICENCE_STATUS } from '../constants/marine-licence.js'
 import { ObjectId } from 'mongodb'
 
 export const preferredDates = {
-  start: new Date('2027-01-01'),
-  end: new Date('2027-12-31')
+  start: { month: '01', year: '2027' },
+  end: { month: '12', year: '2027' }
 }
 
 export const mockMarineLicence = {

--- a/src/marine-licences/models/test-fixtures.js
+++ b/src/marine-licences/models/test-fixtures.js
@@ -1,7 +1,7 @@
 import { MARINE_LICENCE_STATUS } from '../constants/marine-licence.js'
 import { ObjectId } from 'mongodb'
 
-const preferredDates = {
+export const preferredDates = {
   start: new Date('2027-01-01'),
   end: new Date('2027-12-31')
 }

--- a/src/marine-licences/models/test-fixtures.js
+++ b/src/marine-licences/models/test-fixtures.js
@@ -1,6 +1,11 @@
 import { MARINE_LICENCE_STATUS } from '../constants/marine-licence.js'
 import { ObjectId } from 'mongodb'
 
+const preferredDates = {
+  start: new Date('2027-01-01'),
+  end: new Date('2027-12-31')
+}
+
 export const mockMarineLicence = {
   _id: new ObjectId(),
   contactId: 'contact-123-abc',
@@ -9,6 +14,7 @@ export const mockMarineLicence = {
     consent: 'yes',
     reason: 'Test public register reason'
   },
+  preferredDates,
   status: MARINE_LICENCE_STATUS.DRAFT,
   createdAt: new Date('2026-12-01'),
   updatedAt: new Date('2026-12-01')

--- a/tests/test.fixture.js
+++ b/tests/test.fixture.js
@@ -126,6 +126,10 @@ export const createCompleteMarineLicence = (overrides = {}) => {
       consent: 'no',
       reason: 'Test public register details'
     },
+    preferredDates: {
+      start: new Date('2027-01-01'),
+      end: new Date('2027-12-31')
+    },
     status: MARINE_LICENCE_STATUS.DRAFT,
     createdAt: new Date('2026-12-01'),
     updatedAt: new Date('2026-12-01'),

--- a/tests/test.fixture.js
+++ b/tests/test.fixture.js
@@ -127,8 +127,8 @@ export const createCompleteMarineLicence = (overrides = {}) => {
       reason: 'Test public register details'
     },
     preferredDates: {
-      start: new Date('2027-01-01'),
-      end: new Date('2027-12-31')
+      start: { month: '01', year: '2027' },
+      end: { month: '12', year: '2027' }
     },
     status: MARINE_LICENCE_STATUS.DRAFT,
     createdAt: new Date('2026-12-01'),


### PR DESCRIPTION
## Description
 
Preferred Start and End dates API

## Changes

- New Model at top level of Marine Licence
- New API route
- Add to Task List
- Date validation

Depends-On: https://github.com/DEFRA/marine-licensing-frontend/pull/695
Depends-On: https://github.com/DEFRA/marine-licensing-journey-tests/pull/286