### PR TITLE
ML-1240: lcml export site co ordinates for spirit check

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "aws4": "1.13.2",
         "convict": "6.2.5",
         "convict-format-with-validator": "6.2.0",
+        "csv-stringify": "6.7.0",
         "date-fns": "4.3.0",
         "dotenv": "17.4.1",
         "global-agent": "3.0.0",
@@ -8157,6 +8158,12 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "license": "MIT"
+    },
+    "node_modules/csv-stringify": {
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-6.7.0.tgz",
+      "integrity": "sha512-UdtziYp5HuTz7e5j8Nvq+a/3HQo+2/aJZ9xntNTpmRRIg/3YYqDVgiS9fvAhtNbnyfbv2ZBe0bqCHqzhE7FqWQ==",
       "license": "MIT"
     },
     "node_modules/d3": {

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "aws4": "1.13.2",
     "convict": "6.2.5",
     "convict-format-with-validator": "6.2.0",
+    "csv-stringify": "6.7.0",
     "date-fns": "4.3.0",
     "dotenv": "17.4.1",
     "global-agent": "3.0.0",

--- a/src/marine-licences/api/controllers/generate-coordinates-csv.integration.test.js
+++ b/src/marine-licences/api/controllers/generate-coordinates-csv.integration.test.js
@@ -80,8 +80,8 @@ describe('Generate coordinates CSV - integration tests', async () => {
     const lines = response.payload.split('\n').filter(Boolean)
     expect(lines).toHaveLength(3) // header + 2 coordinate rows
 
-    expect(lines[1]).toBe('51,30,0,6,0')
-    expect(lines[2]).toBe('51,36,0,12,0')
+    expect(lines[1]).toBe('51,30,0,6,1')
+    expect(lines[2]).toBe('51,36,0,12,1')
   })
 
   test('returns 403 for a non-Entra ID user', async () => {

--- a/src/marine-licences/api/controllers/generate-coordinates-csv.integration.test.js
+++ b/src/marine-licences/api/controllers/generate-coordinates-csv.integration.test.js
@@ -1,0 +1,40 @@
+import { setupTestServer } from '../../../../tests/test-server.js'
+import { ObjectId } from 'mongodb'
+import { mockMarineLicence } from '../../models/test-fixtures.js'
+
+describe('Generate coordinates CSV - integration tests', async () => {
+  const getServer = await setupTestServer()
+  const contactId = mockMarineLicence.contactId
+
+  const injectGet = (server, id) =>
+    server.inject({
+      method: 'GET',
+      url: `/marine-licence/${id}/generate-coordinates-csv`,
+      auth: {
+        strategy: 'jwt',
+        credentials: { contactId },
+        artifacts: { decoded: {} }
+      }
+    })
+
+  test('returns 200 with correct data', async () => {
+    const marineLicenceId = new ObjectId()
+    await globalThis.mockMongo
+      .collection('marine-licences')
+      .insertOne({ ...mockMarineLicence, _id: marineLicenceId })
+
+    const response = await injectGet(getServer(), marineLicenceId.toString())
+
+    expect(response.statusCode).toBe(200)
+    expect(response.headers['content-type']).toContain('text/csv')
+
+    expect(response.headers['content-disposition']).toBe(
+      'attachment; filename="locationForCSV.csv"'
+    )
+
+    const firstLine = response.payload.split('\n')[0]
+    expect(firstLine).toBe(
+      'Lat Degree,Lat Dec Min,Long Degree,Long Dec Min,objectid'
+    )
+  })
+})

--- a/src/marine-licences/api/controllers/generate-coordinates-csv.integration.test.js
+++ b/src/marine-licences/api/controllers/generate-coordinates-csv.integration.test.js
@@ -78,10 +78,11 @@ describe('Generate coordinates CSV - integration tests', async () => {
     expect(response.statusCode).toBe(200)
 
     const lines = response.payload.split('\n').filter(Boolean)
-    expect(lines).toHaveLength(3) // header + 2 coordinate rows
+    expect(lines).toHaveLength(4) // header + 2 coordinate rows + closing coordinate
 
     expect(lines[1]).toBe('51,30,0,6,1')
     expect(lines[2]).toBe('51,36,0,12,1')
+    expect(lines[3]).toBe('51,30,0,6,1')
   })
 
   test('returns 403 for a non-Entra ID user', async () => {

--- a/src/marine-licences/api/controllers/generate-coordinates-csv.integration.test.js
+++ b/src/marine-licences/api/controllers/generate-coordinates-csv.integration.test.js
@@ -28,7 +28,7 @@ describe('Generate coordinates CSV - integration tests', async () => {
       }
     })
 
-  test('returns 200 with correct data', async () => {
+  test('returns 200 with correct headers', async () => {
     const marineLicenceId = new ObjectId()
     await globalThis.mockMongo
       .collection('marine-licences')
@@ -50,6 +50,38 @@ describe('Generate coordinates CSV - integration tests', async () => {
     expect(firstLine).toBe(
       'Lat Degree,Lat Dec Min,Long Degree,Long Dec Min,objectid'
     )
+  })
+
+  test('returns CSV rows for a polygon site', async () => {
+    const marineLicenceId = new ObjectId()
+    await globalThis.mockMongo.collection('marine-licences').insertOne({
+      ...mockMarineLicence,
+      _id: marineLicenceId,
+      siteDetails: [
+        {
+          coordinatesType: 'polygon',
+          coordinatesEntry: 'multiple',
+          coordinateSystem: 'wgs84',
+          coordinates: [
+            { latitude: '51.5', longitude: '-0.1' },
+            { latitude: '51.6', longitude: '-0.2' }
+          ]
+        }
+      ]
+    })
+
+    const response = await injectAsEntraIdUser(
+      getServer(),
+      marineLicenceId.toString()
+    )
+
+    expect(response.statusCode).toBe(200)
+
+    const lines = response.payload.split('\n').filter(Boolean)
+    expect(lines).toHaveLength(3) // header + 2 coordinate rows
+
+    expect(lines[1]).toBe('51,30,0,6,0')
+    expect(lines[2]).toBe('51,36,0,12,0')
   })
 
   test('returns 403 for a non-Entra ID user', async () => {

--- a/src/marine-licences/api/controllers/generate-coordinates-csv.integration.test.js
+++ b/src/marine-licences/api/controllers/generate-coordinates-csv.integration.test.js
@@ -6,7 +6,18 @@ describe('Generate coordinates CSV - integration tests', async () => {
   const getServer = await setupTestServer()
   const contactId = mockMarineLicence.contactId
 
-  const injectGet = (server, id) =>
+  const injectAsEntraIdUser = (server, id) =>
+    server.inject({
+      method: 'GET',
+      url: `/marine-licence/${id}/generate-coordinates-csv`,
+      auth: {
+        strategy: 'jwt',
+        credentials: { contactId },
+        artifacts: { decoded: { tid: 'tenant-id' } }
+      }
+    })
+
+  const injectAsDefraIdUser = (server, id) =>
     server.inject({
       method: 'GET',
       url: `/marine-licence/${id}/generate-coordinates-csv`,
@@ -23,7 +34,10 @@ describe('Generate coordinates CSV - integration tests', async () => {
       .collection('marine-licences')
       .insertOne({ ...mockMarineLicence, _id: marineLicenceId })
 
-    const response = await injectGet(getServer(), marineLicenceId.toString())
+    const response = await injectAsEntraIdUser(
+      getServer(),
+      marineLicenceId.toString()
+    )
 
     expect(response.statusCode).toBe(200)
     expect(response.headers['content-type']).toContain('text/csv')
@@ -36,5 +50,19 @@ describe('Generate coordinates CSV - integration tests', async () => {
     expect(firstLine).toBe(
       'Lat Degree,Lat Dec Min,Long Degree,Long Dec Min,objectid'
     )
+  })
+
+  test('returns 403 for a non-Entra ID user', async () => {
+    const marineLicenceId = new ObjectId()
+    await globalThis.mockMongo
+      .collection('marine-licences')
+      .insertOne({ ...mockMarineLicence, _id: marineLicenceId })
+
+    const response = await injectAsDefraIdUser(
+      getServer(),
+      marineLicenceId.toString()
+    )
+
+    expect(response.statusCode).toBe(403)
   })
 })

--- a/src/marine-licences/api/controllers/generate-coordinates-csv.js
+++ b/src/marine-licences/api/controllers/generate-coordinates-csv.js
@@ -3,6 +3,7 @@ import { collectionMarineLicences } from '../../../shared/common/constants/db-co
 import { ObjectId } from 'mongodb'
 import { isEntraIdUser } from '../../../shared/helpers/is-entra-id-user.js'
 import Boom from '@hapi/boom'
+import { getSiteCoordinates } from '../csv/site-details.js'
 
 const csvHeaders = [
   'Lat Degree',
@@ -30,6 +31,7 @@ export const generateCoordinatesCsvController = {
     const stream = stringify({ header: true, columns: csvHeaders })
 
     marineLicenceCursor.on('data', (doc) => {
+      const coordinates = getSiteCoordinates(doc.siteDetails) // eslint-disable-line no-unused-vars
       stream.write(doc)
     })
 

--- a/src/marine-licences/api/controllers/generate-coordinates-csv.js
+++ b/src/marine-licences/api/controllers/generate-coordinates-csv.js
@@ -4,6 +4,9 @@ import { ObjectId } from 'mongodb'
 import { isEntraIdUser } from '../../../shared/helpers/is-entra-id-user.js'
 import Boom from '@hapi/boom'
 import { getSiteCoordinates } from '../csv/site-details.js'
+import { convertCoordinatesToDdm } from '../csv/coordinates-to-ddm.js'
+import { csvOutput } from '../csv/csv-output.js'
+import { structureErrorForECS } from '../../../shared/common/helpers/logging/logger.js'
 
 const csvHeaders = [
   'Lat Degree',
@@ -31,8 +34,20 @@ export const generateCoordinatesCsvController = {
     const stream = stringify({ header: true, columns: csvHeaders })
 
     marineLicenceCursor.on('data', (doc) => {
-      const coordinates = getSiteCoordinates(doc.siteDetails) // eslint-disable-line no-unused-vars
-      stream.write(doc)
+      try {
+        const coordinates = getSiteCoordinates(doc.siteDetails)
+        const ddmCoordinates = convertCoordinatesToDdm(coordinates)
+        const csvData = csvOutput(ddmCoordinates)
+        csvData.forEach((row) => {
+          stream.write(row)
+        })
+      } catch (err) {
+        request.logger.error(
+          structureErrorForECS(err),
+          `ERROR: Failed to output CSV file`
+        )
+        stream.destroy(err)
+      }
     })
 
     marineLicenceCursor.on('end', () => stream.end())

--- a/src/marine-licences/api/controllers/generate-coordinates-csv.js
+++ b/src/marine-licences/api/controllers/generate-coordinates-csv.js
@@ -7,6 +7,7 @@ import { getSiteCoordinates } from '../csv/site-details.js'
 import { convertCoordinatesToDdm } from '../csv/coordinates-to-ddm.js'
 import { csvOutput } from '../csv/csv-output.js'
 import { structureErrorForECS } from '../../../shared/common/helpers/logging/logger.js'
+import { coordinatesToCsvObject } from '../csv/coordinates-to-csv.js'
 
 const csvHeaders = [
   'Lat Degree',
@@ -37,7 +38,8 @@ export const generateCoordinatesCsvController = {
       try {
         const coordinates = getSiteCoordinates(doc.siteDetails)
         const ddmCoordinates = convertCoordinatesToDdm(coordinates)
-        const csvData = csvOutput(ddmCoordinates)
+        const parsedDdmCoordinates = coordinatesToCsvObject(ddmCoordinates)
+        const csvData = csvOutput(parsedDdmCoordinates)
         csvData.forEach((row) => {
           stream.write(row)
         })

--- a/src/marine-licences/api/controllers/generate-coordinates-csv.js
+++ b/src/marine-licences/api/controllers/generate-coordinates-csv.js
@@ -42,7 +42,7 @@ export const generateCoordinatesCsvController = {
 
     const siteTransform = new Transform({
       objectMode: true,
-      transform([index, site], _, callback) {
+      transform([_index, site], _, callback) {
         const coords = getSiteCoordinates([site])
         const ddm = convertCoordinatesToDdm(coords)
         const csvObjects = coordinatesToCsvObject(ddm)

--- a/src/marine-licences/api/controllers/generate-coordinates-csv.js
+++ b/src/marine-licences/api/controllers/generate-coordinates-csv.js
@@ -1,6 +1,8 @@
 import { stringify } from 'csv-stringify'
 import { collectionMarineLicences } from '../../../shared/common/constants/db-collections.js'
 import { ObjectId } from 'mongodb'
+import { isEntraIdUser } from '../../../shared/helpers/is-entra-id-user.js'
+import Boom from '@hapi/boom'
 
 const csvHeaders = [
   'Lat Degree',
@@ -12,6 +14,12 @@ const csvHeaders = [
 
 export const generateCoordinatesCsvController = {
   handler: async (request, h) => {
+    const isUserEntraIdUser = isEntraIdUser(request)
+
+    if (!isUserEntraIdUser) {
+      throw Boom.forbidden('Not authorised to view CSV data')
+    }
+
     const { params, db } = request
 
     const marineLicenceCursor = db

--- a/src/marine-licences/api/controllers/generate-coordinates-csv.js
+++ b/src/marine-licences/api/controllers/generate-coordinates-csv.js
@@ -42,11 +42,11 @@ export const generateCoordinatesCsvController = {
 
     const siteTransform = new Transform({
       objectMode: true,
-      transform([_index, site], _, callback) {
+      transform([index, site], _, callback) {
         const coords = getSiteCoordinates([site])
         const ddm = convertCoordinatesToDdm(coords)
         const csvObjects = coordinatesToCsvObject(ddm)
-        for (const row of csvOutput(csvObjects)) {
+        for (const row of csvOutput(csvObjects, index)) {
           this.push(row)
         }
         callback()

--- a/src/marine-licences/api/controllers/generate-coordinates-csv.js
+++ b/src/marine-licences/api/controllers/generate-coordinates-csv.js
@@ -1,3 +1,4 @@
+import { Transform } from 'node:stream'
 import { stringify } from 'csv-stringify'
 import { collectionMarineLicences } from '../../../shared/common/constants/db-collections.js'
 import { ObjectId } from 'mongodb'
@@ -6,7 +7,6 @@ import Boom from '@hapi/boom'
 import { getSiteCoordinates } from '../csv/site-details.js'
 import { convertCoordinatesToDdm } from '../csv/coordinates-to-ddm.js'
 import { csvOutput } from '../csv/csv-output.js'
-import { structureErrorForECS } from '../../../shared/common/helpers/logging/logger.js'
 import { coordinatesToCsvObject } from '../csv/coordinates-to-csv.js'
 
 const csvHeaders = [
@@ -27,33 +27,41 @@ export const generateCoordinatesCsvController = {
 
     const { params, db } = request
 
-    const stream = stringify({ header: true, columns: csvHeaders })
-    const marineLicenceCursor = db
+    const doc = await db
       .collection(collectionMarineLicences)
-      .find({ _id: ObjectId.createFromHexString(params.id) })
-      .stream()
+      .findOne(
+        { _id: ObjectId.createFromHexString(params.id) },
+        { projection: { siteDetails: 1 } }
+      )
 
-    marineLicenceCursor.on('data', (doc) => {
-      try {
-        const coordinates = getSiteCoordinates(doc.siteDetails)
-        const ddmCoordinates = convertCoordinatesToDdm(coordinates)
-        const parsedDdmCoordinates = coordinatesToCsvObject(ddmCoordinates)
-        const csvData = csvOutput(parsedDdmCoordinates)
-        csvData.forEach((row) => stream.write(row))
-      } catch (err) {
-        request.logger.error(
-          structureErrorForECS(err),
-          `Failed to output CSV file`
-        )
-        stream.destroy(err)
+    if (!doc) {
+      throw Boom.notFound('Marine licence not found')
+    }
+
+    const csvStream = stringify({ header: true, columns: csvHeaders })
+
+    const siteTransform = new Transform({
+      objectMode: true,
+      transform([index, site], _, callback) {
+        const coords = getSiteCoordinates([site])
+        const ddm = convertCoordinatesToDdm(coords)
+        const csvObjects = coordinatesToCsvObject(ddm)
+        for (const row of csvOutput(csvObjects)) {
+          this.push(row)
+        }
+        callback()
       }
     })
 
-    marineLicenceCursor.on('end', () => stream.end())
-    marineLicenceCursor.on('error', (err) => stream.destroy(err))
+    siteTransform.pipe(csvStream)
+
+    for (const entry of (doc.siteDetails ?? []).entries()) {
+      siteTransform.write(entry)
+    }
+    siteTransform.end()
 
     return h
-      .response(stream)
+      .response(csvStream)
       .type('text/csv')
       .header(
         'Content-Disposition',

--- a/src/marine-licences/api/controllers/generate-coordinates-csv.js
+++ b/src/marine-licences/api/controllers/generate-coordinates-csv.js
@@ -27,12 +27,11 @@ export const generateCoordinatesCsvController = {
 
     const { params, db } = request
 
+    const stream = stringify({ header: true, columns: csvHeaders })
     const marineLicenceCursor = db
       .collection(collectionMarineLicences)
       .find({ _id: ObjectId.createFromHexString(params.id) })
       .stream()
-
-    const stream = stringify({ header: true, columns: csvHeaders })
 
     marineLicenceCursor.on('data', (doc) => {
       try {
@@ -40,13 +39,11 @@ export const generateCoordinatesCsvController = {
         const ddmCoordinates = convertCoordinatesToDdm(coordinates)
         const parsedDdmCoordinates = coordinatesToCsvObject(ddmCoordinates)
         const csvData = csvOutput(parsedDdmCoordinates)
-        csvData.forEach((row) => {
-          stream.write(row)
-        })
+        csvData.forEach((row) => stream.write(row))
       } catch (err) {
         request.logger.error(
           structureErrorForECS(err),
-          `ERROR: Failed to output CSV file`
+          `Failed to output CSV file`
         )
         stream.destroy(err)
       }

--- a/src/marine-licences/api/controllers/generate-coordinates-csv.js
+++ b/src/marine-licences/api/controllers/generate-coordinates-csv.js
@@ -1,0 +1,39 @@
+import { stringify } from 'csv-stringify'
+import { collectionMarineLicences } from '../../../shared/common/constants/db-collections.js'
+import { ObjectId } from 'mongodb'
+
+const csvHeaders = [
+  'Lat Degree',
+  'Lat Dec Min',
+  'Long Degree',
+  'Long Dec Min',
+  'objectid'
+]
+
+export const generateCoordinatesCsvController = {
+  handler: async (request, h) => {
+    const { params, db } = request
+
+    const marineLicenceCursor = db
+      .collection(collectionMarineLicences)
+      .find({ _id: ObjectId.createFromHexString(params.id) })
+      .stream()
+
+    const stream = stringify({ header: true, columns: csvHeaders })
+
+    marineLicenceCursor.on('data', (doc) => {
+      stream.write(doc)
+    })
+
+    marineLicenceCursor.on('end', () => stream.end())
+    marineLicenceCursor.on('error', (err) => stream.destroy(err))
+
+    return h
+      .response(stream)
+      .type('text/csv')
+      .header(
+        'Content-Disposition',
+        'attachment; filename="locationForCSV.csv"'
+      )
+  }
+}

--- a/src/marine-licences/api/controllers/generate-coordinates-csv.test.js
+++ b/src/marine-licences/api/controllers/generate-coordinates-csv.test.js
@@ -2,6 +2,7 @@ import { EventEmitter } from 'events'
 import { vi } from 'vitest'
 import { generateCoordinatesCsvController } from './generate-coordinates-csv.js'
 import * as siteDetailsModule from '../csv/site-details.js'
+import * as csvOutputModule from '../csv/csv-output.js'
 
 describe('GET /marine-licence/{id}/generate-coordinates-csv', () => {
   const mockId = 'a'.repeat(24)
@@ -77,26 +78,28 @@ describe('GET /marine-licence/{id}/generate-coordinates-csv', () => {
     expect(getSiteCoordinatesSpy).toHaveBeenCalledWith(mockDoc.siteDetails)
   })
 
-  it('should write each doc from the cursor into the csv stream', async () => {
-    await generateCoordinatesCsvController.handler(mockRequest, mockH)
-
-    const csvStream = mockH.response.mock.calls[0][0]
-    const writeSpy = vi.spyOn(csvStream, 'write')
-
-    const mockDoc = {
+  it('should write each row returned by csvOutput into the csv stream', async () => {
+    const mockRow = {
       'Lat Degree': 51,
       'Lat Dec Min': 30,
       'Long Degree': -1,
       'Long Dec Min': 15,
       objectid: 1
     }
-    mockCursor.emit('data', mockDoc)
+    vi.spyOn(csvOutputModule, 'csvOutput').mockReturnValue([mockRow])
+
+    await generateCoordinatesCsvController.handler(mockRequest, mockH)
+
+    const csvStream = mockH.response.mock.calls[0][0]
+    const writeSpy = vi.spyOn(csvStream, 'write')
+
+    mockCursor.emit('data', { siteDetails: [] })
 
     expect(mockRequest.db.collection).toHaveBeenCalledWith('marine-licences')
     expect(
       mockRequest.db.collection('marine-licences').find
     ).toHaveBeenCalledWith(expect.objectContaining({ _id: expect.anything() }))
 
-    expect(writeSpy).toHaveBeenCalledWith(mockDoc)
+    expect(writeSpy).toHaveBeenCalledWith(mockRow)
   })
 })

--- a/src/marine-licences/api/controllers/generate-coordinates-csv.test.js
+++ b/src/marine-licences/api/controllers/generate-coordinates-csv.test.js
@@ -1,4 +1,3 @@
-import { EventEmitter } from 'events'
 import { vi } from 'vitest'
 import { generateCoordinatesCsvController } from './generate-coordinates-csv.js'
 import * as siteDetailsModule from '../csv/site-details.js'
@@ -7,16 +6,27 @@ import * as csvOutputModule from '../csv/csv-output.js'
 describe('GET /marine-licence/{id}/generate-coordinates-csv', () => {
   const mockId = 'a'.repeat(24)
 
-  let mockCursor
+  const mockSite = {
+    coordinatesType: 'coordinates',
+    coordinatesEntry: 'single',
+    coordinateSystem: 'wgs84',
+    coordinates: { latitude: '51.5', longitude: '-0.1' },
+    circleWidth: '100'
+  }
+
+  const mockDoc = { siteDetails: [mockSite] }
+
+  let mockFindOne
   let mockRequest
   let mockH
 
-  beforeEach(() => {
-    mockCursor = new EventEmitter()
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
 
-    const mockStream = vi.fn().mockReturnValue(mockCursor)
-    const mockFind = vi.fn().mockReturnValue({ stream: mockStream })
-    const mockCollection = vi.fn().mockReturnValue({ find: mockFind })
+  beforeEach(() => {
+    mockFindOne = vi.fn().mockResolvedValue(mockDoc)
+    const mockCollection = vi.fn().mockReturnValue({ findOne: mockFindOne })
 
     mockRequest = {
       auth: { artifacts: { decoded: { tid: 'tenant-id' } } },
@@ -32,80 +42,50 @@ describe('GET /marine-licence/{id}/generate-coordinates-csv', () => {
     }
   })
 
-  it('should destroy the csv stream when the cursor emits an error', async () => {
-    await generateCoordinatesCsvController.handler(mockRequest, mockH)
+  it('should return 403 when user is not an Entra ID user', async () => {
+    mockRequest.auth.artifacts.decoded = {}
 
-    const csvStream = mockH.response.mock.calls[0][0]
-    const destroySpy = vi.spyOn(csvStream, 'destroy')
-    csvStream.on('error', () => {})
-
-    const err = new Error('cursor error')
-    mockCursor.emit('error', err)
-
-    expect(destroySpy).toHaveBeenCalledWith(err)
+    await expect(
+      generateCoordinatesCsvController.handler(mockRequest, mockH)
+    ).rejects.toThrow('Not authorised to view CSV data')
   })
 
-  it('should end the csv stream when the cursor ends', async () => {
-    await generateCoordinatesCsvController.handler(mockRequest, mockH)
+  it('should throw a 404 when the document is not found', async () => {
+    mockFindOne.mockResolvedValue(null)
 
-    const csvStream = mockH.response.mock.calls[0][0]
-    const endSpy = vi.spyOn(csvStream, 'end')
-
-    mockCursor.emit('end')
-
-    expect(endSpy).toHaveBeenCalled()
+    await expect(
+      generateCoordinatesCsvController.handler(mockRequest, mockH)
+    ).rejects.toThrow('Marine licence not found')
   })
 
-  it('should call getSiteCoordinates with doc.siteDetails when the cursor emits data', async () => {
+  it('should call getSiteCoordinates once per site', async () => {
     const getSiteCoordinatesSpy = vi.spyOn(
       siteDetailsModule,
       'getSiteCoordinates'
     )
-    await generateCoordinatesCsvController.handler(mockRequest, mockH)
-
-    const mockDoc = {
-      siteDetails: [
-        {
-          coordinatesType: 'coordinates',
-          coordinatesEntry: 'single',
-          coordinateSystem: 'wgs84',
-          coordinates: { latitude: '51.5', longitude: '-0.1' },
-          circleWidth: '100'
-        }
-      ]
-    }
-    mockCursor.emit('data', mockDoc)
-
-    expect(getSiteCoordinatesSpy).toHaveBeenCalledWith(mockDoc.siteDetails)
-  })
-
-  it('should write each row returned by csvOutput into the csv stream', async () => {
-    const mockRow = [51, 30, 0, 15, 0]
-    vi.spyOn(csvOutputModule, 'csvOutput').mockReturnValue([mockRow])
 
     await generateCoordinatesCsvController.handler(mockRequest, mockH)
 
-    const csvStream = mockH.response.mock.calls[0][0]
-    const writeSpy = vi.spyOn(csvStream, 'write')
-
-    mockCursor.emit('data', { siteDetails: [] })
-
-    expect(writeSpy).toHaveBeenCalledWith(mockRow)
+    expect(getSiteCoordinatesSpy).toHaveBeenCalledTimes(1)
+    expect(getSiteCoordinatesSpy).toHaveBeenCalledWith([mockSite])
   })
 
-  it('should log an error and destroy the stream when processing fails', async () => {
+  it('should call csvOutput once per site', async () => {
+    const csvOutputSpy = vi.spyOn(csvOutputModule, 'csvOutput')
+
+    await generateCoordinatesCsvController.handler(mockRequest, mockH)
+
+    expect(csvOutputSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('should throw when processing a site fails', async () => {
     vi.spyOn(siteDetailsModule, 'getSiteCoordinates').mockImplementation(() => {
       throw new Error('processing failed')
     })
 
-    await generateCoordinatesCsvController.handler(mockRequest, mockH)
-
-    const csvStream = mockH.response.mock.calls[0][0]
-    csvStream.on('error', () => {})
-
-    mockCursor.emit('data', { siteDetails: [] })
-
-    expect(mockRequest.logger.error).toHaveBeenCalled()
+    await expect(
+      generateCoordinatesCsvController.handler(mockRequest, mockH)
+    ).rejects.toThrow('processing failed')
   })
 
   it('should return the stream with csv content-type and content-disposition headers', async () => {

--- a/src/marine-licences/api/controllers/generate-coordinates-csv.test.js
+++ b/src/marine-licences/api/controllers/generate-coordinates-csv.test.js
@@ -1,0 +1,77 @@
+import { EventEmitter } from 'events'
+import { vi } from 'vitest'
+import { generateCoordinatesCsvController } from './generate-coordinates-csv.js'
+
+describe('GET /marine-licence/{id}/generate-coordinates-csv', () => {
+  const mockId = 'a'.repeat(24)
+
+  let mockCursor
+  let mockRequest
+  let mockH
+
+  beforeEach(() => {
+    mockCursor = new EventEmitter()
+
+    const mockStream = vi.fn().mockReturnValue(mockCursor)
+    const mockFind = vi.fn().mockReturnValue({ stream: mockStream })
+    const mockCollection = vi.fn().mockReturnValue({ find: mockFind })
+
+    mockRequest = {
+      params: { id: mockId },
+      db: { collection: mockCollection }
+    }
+
+    mockH = {
+      response: vi.fn().mockReturnThis(),
+      type: vi.fn().mockReturnThis(),
+      header: vi.fn().mockReturnThis()
+    }
+  })
+
+  it('should destroy the csv stream when the cursor emits an error', async () => {
+    await generateCoordinatesCsvController.handler(mockRequest, mockH)
+
+    const csvStream = mockH.response.mock.calls[0][0]
+    const destroySpy = vi.spyOn(csvStream, 'destroy')
+    csvStream.on('error', () => {})
+
+    const err = new Error('cursor error')
+    mockCursor.emit('error', err)
+
+    expect(destroySpy).toHaveBeenCalledWith(err)
+  })
+
+  it('should end the csv stream when the cursor ends', async () => {
+    await generateCoordinatesCsvController.handler(mockRequest, mockH)
+
+    const csvStream = mockH.response.mock.calls[0][0]
+    const endSpy = vi.spyOn(csvStream, 'end')
+
+    mockCursor.emit('end')
+
+    expect(endSpy).toHaveBeenCalled()
+  })
+
+  it('should write each doc from the cursor into the csv stream', async () => {
+    await generateCoordinatesCsvController.handler(mockRequest, mockH)
+
+    const csvStream = mockH.response.mock.calls[0][0]
+    const writeSpy = vi.spyOn(csvStream, 'write')
+
+    const mockDoc = {
+      'Lat Degree': 51,
+      'Lat Dec Min': 30,
+      'Long Degree': -1,
+      'Long Dec Min': 15,
+      objectid: 1
+    }
+    mockCursor.emit('data', mockDoc)
+
+    expect(mockRequest.db.collection).toHaveBeenCalledWith('marine-licences')
+    expect(
+      mockRequest.db.collection('marine-licences').find
+    ).toHaveBeenCalledWith(expect.objectContaining({ _id: expect.anything() }))
+
+    expect(writeSpy).toHaveBeenCalledWith(mockDoc)
+  })
+})

--- a/src/marine-licences/api/controllers/generate-coordinates-csv.test.js
+++ b/src/marine-licences/api/controllers/generate-coordinates-csv.test.js
@@ -21,7 +21,8 @@ describe('GET /marine-licence/{id}/generate-coordinates-csv', () => {
     mockRequest = {
       auth: { artifacts: { decoded: { tid: 'tenant-id' } } },
       params: { id: mockId },
-      db: { collection: mockCollection }
+      db: { collection: mockCollection },
+      logger: { error: vi.fn() }
     }
 
     mockH = {
@@ -79,13 +80,7 @@ describe('GET /marine-licence/{id}/generate-coordinates-csv', () => {
   })
 
   it('should write each row returned by csvOutput into the csv stream', async () => {
-    const mockRow = {
-      'Lat Degree': 51,
-      'Lat Dec Min': 30,
-      'Long Degree': -1,
-      'Long Dec Min': 15,
-      objectid: 1
-    }
+    const mockRow = [51, 30, 0, 15, 0]
     vi.spyOn(csvOutputModule, 'csvOutput').mockReturnValue([mockRow])
 
     await generateCoordinatesCsvController.handler(mockRequest, mockH)
@@ -95,11 +90,31 @@ describe('GET /marine-licence/{id}/generate-coordinates-csv', () => {
 
     mockCursor.emit('data', { siteDetails: [] })
 
-    expect(mockRequest.db.collection).toHaveBeenCalledWith('marine-licences')
-    expect(
-      mockRequest.db.collection('marine-licences').find
-    ).toHaveBeenCalledWith(expect.objectContaining({ _id: expect.anything() }))
-
     expect(writeSpy).toHaveBeenCalledWith(mockRow)
+  })
+
+  it('should log an error and destroy the stream when processing fails', async () => {
+    vi.spyOn(siteDetailsModule, 'getSiteCoordinates').mockImplementation(() => {
+      throw new Error('processing failed')
+    })
+
+    await generateCoordinatesCsvController.handler(mockRequest, mockH)
+
+    const csvStream = mockH.response.mock.calls[0][0]
+    csvStream.on('error', () => {})
+
+    mockCursor.emit('data', { siteDetails: [] })
+
+    expect(mockRequest.logger.error).toHaveBeenCalled()
+  })
+
+  it('should return the stream with csv content-type and content-disposition headers', async () => {
+    await generateCoordinatesCsvController.handler(mockRequest, mockH)
+
+    expect(mockH.type).toHaveBeenCalledWith('text/csv')
+    expect(mockH.header).toHaveBeenCalledWith(
+      'Content-Disposition',
+      'attachment; filename="locationForCSV.csv"'
+    )
   })
 })

--- a/src/marine-licences/api/controllers/generate-coordinates-csv.test.js
+++ b/src/marine-licences/api/controllers/generate-coordinates-csv.test.js
@@ -17,6 +17,7 @@ describe('GET /marine-licence/{id}/generate-coordinates-csv', () => {
     const mockCollection = vi.fn().mockReturnValue({ find: mockFind })
 
     mockRequest = {
+      auth: { artifacts: { decoded: { tid: 'tenant-id' } } },
       params: { id: mockId },
       db: { collection: mockCollection }
     }

--- a/src/marine-licences/api/controllers/generate-coordinates-csv.test.js
+++ b/src/marine-licences/api/controllers/generate-coordinates-csv.test.js
@@ -1,6 +1,7 @@
 import { EventEmitter } from 'events'
 import { vi } from 'vitest'
 import { generateCoordinatesCsvController } from './generate-coordinates-csv.js'
+import * as siteDetailsModule from '../csv/site-details.js'
 
 describe('GET /marine-licence/{id}/generate-coordinates-csv', () => {
   const mockId = 'a'.repeat(24)
@@ -51,6 +52,29 @@ describe('GET /marine-licence/{id}/generate-coordinates-csv', () => {
     mockCursor.emit('end')
 
     expect(endSpy).toHaveBeenCalled()
+  })
+
+  it('should call getSiteCoordinates with doc.siteDetails when the cursor emits data', async () => {
+    const getSiteCoordinatesSpy = vi.spyOn(
+      siteDetailsModule,
+      'getSiteCoordinates'
+    )
+    await generateCoordinatesCsvController.handler(mockRequest, mockH)
+
+    const mockDoc = {
+      siteDetails: [
+        {
+          coordinatesType: 'coordinates',
+          coordinatesEntry: 'single',
+          coordinateSystem: 'wgs84',
+          coordinates: { latitude: '51.5', longitude: '-0.1' },
+          circleWidth: '100'
+        }
+      ]
+    }
+    mockCursor.emit('data', mockDoc)
+
+    expect(getSiteCoordinatesSpy).toHaveBeenCalledWith(mockDoc.siteDetails)
   })
 
   it('should write each doc from the cursor into the csv stream', async () => {

--- a/src/marine-licences/api/controllers/get-marine-licence.js
+++ b/src/marine-licences/api/controllers/get-marine-licence.js
@@ -5,6 +5,7 @@ import { createTaskList } from '../helpers/createTaskList.js'
 import { MarineLicenceService } from '../services/marine-licence.service.js'
 import { getContactId } from '../../../shared/helpers/get-contact-id.js'
 import { getOrganisationDetailsFromAuthToken } from '../../../shared/helpers/get-organisation-from-token.js'
+import { isApplicantUser } from '../../../exemptions/api/helpers/is-applicant-user.js'
 
 export const getMarineLicenceController = ({ requiresAuth }) => ({
   options: {
@@ -25,7 +26,8 @@ export const getMarineLicenceController = ({ requiresAuth }) => ({
       let marineLicence
 
       if (requiresAuth) {
-        const currentUserId = getContactId(request.auth)
+        const isApplicant = isApplicantUser(request)
+        const currentUserId = isApplicant ? getContactId(request.auth) : null
         marineLicence = await marineLicenceService.getMarineLicenceById({
           id,
           currentUserId

--- a/src/marine-licences/api/controllers/get-marine-licence.test.js
+++ b/src/marine-licences/api/controllers/get-marine-licence.test.js
@@ -1,6 +1,9 @@
 import { getMarineLicenceController } from './get-marine-licence.js'
 import { vi } from 'vitest'
-import { requestFromApplicantUser } from '../../../../.vite/mocks.js'
+import {
+  requestFromApplicantUser,
+  requestFromInternalUser
+} from '../../../../.vite/mocks.js'
 import { MARINE_LICENCE_STATUS } from '../../constants/marine-licence.js'
 import { preferredDates } from '../../models/test-fixtures.js'
 
@@ -137,6 +140,25 @@ describe('GET /marine-licence', () => {
             }
           }
         })
+      )
+    })
+
+    it('should allow an internal (Entra ID) user to access any marine licence', async () => {
+      const { mockHandler } = global
+
+      mockedFindOne.mockResolvedValue({
+        _id: mockId,
+        projectName: 'Test project',
+        contactId: 'someone-elses-id'
+      })
+
+      await authenticatedController.handler(
+        requestFromInternalUser({ params: { id: mockId } }),
+        mockHandler
+      )
+
+      expect(mockHandler.response).toHaveBeenCalledWith(
+        expect.objectContaining({ message: 'success' })
       )
     })
 

--- a/src/marine-licences/api/csv/coordinates-to-csv.js
+++ b/src/marine-licences/api/csv/coordinates-to-csv.js
@@ -1,0 +1,23 @@
+const parseDdm = (ddmString) => {
+  const [degrees, minutesAndDirection] = ddmString.split('° ')
+  const [decimalMinutes] = minutesAndDirection.split("' ")
+  return { degrees: Number(degrees), decimalMinutes: Number(decimalMinutes) }
+}
+
+const pointToCsvRow = ({ lat, lon }) => {
+  const latParsed = parseDdm(lat)
+  const lonParsed = parseDdm(lon)
+  return {
+    latDegree: latParsed.degrees,
+    latDecMin: latParsed.decimalMinutes,
+    longDegree: lonParsed.degrees,
+    longDecMin: lonParsed.decimalMinutes
+  }
+}
+
+/**
+ * Converts DDM coordinates to CSV row objects.
+ * All site types produce: [{ latDegree, latDecMin, longDegree, longDecMin }, ...]
+ */
+export const coordinatesToCsvObject = (siteCoordinates) =>
+  siteCoordinates.map((site) => site.map(pointToCsvRow))

--- a/src/marine-licences/api/csv/coordinates-to-csv.test.js
+++ b/src/marine-licences/api/csv/coordinates-to-csv.test.js
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest'
+import { coordinatesToCsvObject } from './coordinates-to-csv.js'
+
+describe('coordinatesToCsvObject', () => {
+  describe('valid sites', () => {
+    it('converts a single point to a CSV row object', () => {
+      const result = coordinatesToCsvObject([
+        [{ lat: "51° 30.0' N", lon: "0° 7.5' W" }]
+      ])
+
+      expect(result).toEqual([
+        [{ latDegree: 51, latDecMin: 30.0, longDegree: 0, longDecMin: 7.5 }]
+      ])
+    })
+
+    it('converts multiple points in a site', () => {
+      const site = [
+        { lat: "51° 30.0' N", lon: "0° 7.5' W" },
+        { lat: "52° 15.5' N", lon: "1° 20.0' E" }
+      ]
+
+      const result = coordinatesToCsvObject([site])
+
+      expect(result).toEqual([
+        [
+          { latDegree: 51, latDecMin: 30.0, longDegree: 0, longDecMin: 7.5 },
+          { latDegree: 52, latDecMin: 15.5, longDegree: 1, longDecMin: 20.0 }
+        ]
+      ])
+    })
+  })
+
+  describe('edge cases', () => {
+    it('returns an empty array for empty input', () => {
+      expect(coordinatesToCsvObject([])).toEqual([])
+    })
+
+    it('returns an empty array for a site with no points', () => {
+      expect(coordinatesToCsvObject([[]])).toEqual([[]])
+    })
+  })
+})

--- a/src/marine-licences/api/csv/coordinates-to-ddm.js
+++ b/src/marine-licences/api/csv/coordinates-to-ddm.js
@@ -5,18 +5,18 @@ const convertPointsToDDM = ([lon, lat]) => ({
   lon: coordinatesToDegreesDecimalMinutes(lon, false)
 })
 
-const convertSite = (ring) => ring.map(convertPointsToDDM)
+const convertSite = (feature) => feature.map(convertPointsToDDM)
 
 /**
  * Converts a site coordinates array (output of getSiteCoordinates) to DDM format.
+ * File upload features are flattened into a single array, matching the manual site structure.
  *
- * - Circle/polygon sites: site of [lon, lat] pairs → site of of { lat, lon } DDM strings
- * - File upload sites: array of feature sites → same structure with DDM strings
+ * Both site types produce: [{ lat, lon }, ...]
  */
 export const convertCoordinatesToDdm = (siteCoordinates) =>
   siteCoordinates.map((site) => {
     if (Array.isArray(site[0]?.[0])) {
-      return site.map(convertSite)
+      return site.flatMap(convertSite)
     }
     return convertSite(site)
   })

--- a/src/marine-licences/api/csv/coordinates-to-ddm.js
+++ b/src/marine-licences/api/csv/coordinates-to-ddm.js
@@ -1,0 +1,22 @@
+import { coordinatesToDegreesDecimalMinutes } from '../../../shared/common/helpers/geo/geo-transforms.js'
+
+const convertPointsToDDM = ([lon, lat]) => ({
+  lat: coordinatesToDegreesDecimalMinutes(lat, true),
+  lon: coordinatesToDegreesDecimalMinutes(lon, false)
+})
+
+const convertSite = (ring) => ring.map(convertPointsToDDM)
+
+/**
+ * Converts a site coordinates array (output of getSiteCoordinates) to DDM format.
+ *
+ * - Circle/polygon sites: site of [lon, lat] pairs → site of of { lat, lon } DDM strings
+ * - File upload sites: array of feature sites → same structure with DDM strings
+ */
+export const convertCoordinatesToDdm = (siteCoordinates) =>
+  siteCoordinates.map((site) => {
+    if (Array.isArray(site[0]?.[0])) {
+      return site.map(convertSite)
+    }
+    return convertSite(site)
+  })

--- a/src/marine-licences/api/csv/coordinates-to-ddm.test.js
+++ b/src/marine-licences/api/csv/coordinates-to-ddm.test.js
@@ -15,14 +15,14 @@ beforeEach(() => {
 
 describe('convertCoordinatesToDdm', () => {
   describe('circle and polygon sites', () => {
-    it('converts each point in the ring to a DDM { lat, lon } object', () => {
-      const ring = [
+    it('converts each point in the feature to a DDM { lat, lon } object', () => {
+      const feature = [
         [-0.1, 51.5],
         [-0.2, 51.6],
         [-0.1, 51.5]
       ]
 
-      const result = convertCoordinatesToDdm([ring])
+      const result = convertCoordinatesToDdm([feature])
 
       expect(result).toEqual([
         [
@@ -34,9 +34,9 @@ describe('convertCoordinatesToDdm', () => {
     })
 
     it('calls coordinatesToDegreesDecimalMinutes with lat as isLatitude=true and lon as isLatitude=false', () => {
-      const ring = [[-0.1, 51.5]]
+      const feature = [[-0.1, 51.5]]
 
-      convertCoordinatesToDdm([ring])
+      convertCoordinatesToDdm([feature])
 
       expect(coordinatesToDegreesDecimalMinutes).toHaveBeenCalledWith(
         51.5,
@@ -49,36 +49,33 @@ describe('convertCoordinatesToDdm', () => {
     })
 
     it('returns one entry per site', () => {
-      const ring1 = [[-0.1, 51.5]]
-      const ring2 = [[-1.0, 52.0]]
+      const feature1 = [[-0.1, 51.5]]
+      const feature2 = [[-1.0, 52.0]]
 
-      const result = convertCoordinatesToDdm([ring1, ring2])
+      const result = convertCoordinatesToDdm([feature1, feature2])
 
       expect(result).toHaveLength(2)
     })
   })
 
   describe('file upload sites', () => {
-    it('converts each feature ring preserving the nested structure', () => {
-      const ring1 = [
+    it('flattens all feature features into a single array matching the manual site structure', () => {
+      const feature1 = [
         [-1.0, 50.0],
         [-1.0, 51.0]
       ]
-      const ring2 = [
+      const feature2 = [
         [-3.0, 52.0],
         [-4.0, 53.0]
       ]
-      const fileUploadSite = [ring1, ring2]
+      const fileUploadSite = [feature1, feature2]
 
       const result = convertCoordinatesToDdm([fileUploadSite])
 
       expect(result).toHaveLength(1)
-      expect(result[0]).toHaveLength(2)
-      expect(result[0][0]).toEqual([
+      expect(result[0]).toEqual([
         { lat: '50° N', lon: '-1° W' },
-        { lat: '51° N', lon: '-1° W' }
-      ])
-      expect(result[0][1]).toEqual([
+        { lat: '51° N', lon: '-1° W' },
         { lat: '52° N', lon: '-3° W' },
         { lat: '53° N', lon: '-4° W' }
       ])

--- a/src/marine-licences/api/csv/coordinates-to-ddm.test.js
+++ b/src/marine-licences/api/csv/coordinates-to-ddm.test.js
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { convertCoordinatesToDdm } from './coordinates-to-ddm.js'
+import { coordinatesToDegreesDecimalMinutes } from '../../../shared/common/helpers/geo/geo-transforms.js'
+
+vi.mock('../../../shared/common/helpers/geo/geo-transforms.js', () => ({
+  coordinatesToDegreesDecimalMinutes: vi.fn()
+}))
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  coordinatesToDegreesDecimalMinutes.mockImplementation((value, isLatitude) =>
+    isLatitude ? `${value}° N` : `${value}° W`
+  )
+})
+
+describe('convertCoordinatesToDdm', () => {
+  describe('circle and polygon sites', () => {
+    it('converts each point in the ring to a DDM { lat, lon } object', () => {
+      const ring = [
+        [-0.1, 51.5],
+        [-0.2, 51.6],
+        [-0.1, 51.5]
+      ]
+
+      const result = convertCoordinatesToDdm([ring])
+
+      expect(result).toEqual([
+        [
+          { lat: '51.5° N', lon: '-0.1° W' },
+          { lat: '51.6° N', lon: '-0.2° W' },
+          { lat: '51.5° N', lon: '-0.1° W' }
+        ]
+      ])
+    })
+
+    it('calls coordinatesToDegreesDecimalMinutes with lat as isLatitude=true and lon as isLatitude=false', () => {
+      const ring = [[-0.1, 51.5]]
+
+      convertCoordinatesToDdm([ring])
+
+      expect(coordinatesToDegreesDecimalMinutes).toHaveBeenCalledWith(
+        51.5,
+        true
+      )
+      expect(coordinatesToDegreesDecimalMinutes).toHaveBeenCalledWith(
+        -0.1,
+        false
+      )
+    })
+
+    it('returns one entry per site', () => {
+      const ring1 = [[-0.1, 51.5]]
+      const ring2 = [[-1.0, 52.0]]
+
+      const result = convertCoordinatesToDdm([ring1, ring2])
+
+      expect(result).toHaveLength(2)
+    })
+  })
+
+  describe('file upload sites', () => {
+    it('converts each feature ring preserving the nested structure', () => {
+      const ring1 = [
+        [-1.0, 50.0],
+        [-1.0, 51.0]
+      ]
+      const ring2 = [
+        [-3.0, 52.0],
+        [-4.0, 53.0]
+      ]
+      const fileUploadSite = [ring1, ring2]
+
+      const result = convertCoordinatesToDdm([fileUploadSite])
+
+      expect(result).toHaveLength(1)
+      expect(result[0]).toHaveLength(2)
+      expect(result[0][0]).toEqual([
+        { lat: '50° N', lon: '-1° W' },
+        { lat: '51° N', lon: '-1° W' }
+      ])
+      expect(result[0][1]).toEqual([
+        { lat: '52° N', lon: '-3° W' },
+        { lat: '53° N', lon: '-4° W' }
+      ])
+    })
+  })
+
+  describe('edge cases', () => {
+    it('returns an empty array for empty input', () => {
+      expect(convertCoordinatesToDdm([])).toEqual([])
+    })
+
+    it('propagates errors thrown by coordinatesToDegreesDecimalMinutes', () => {
+      coordinatesToDegreesDecimalMinutes.mockImplementation(() => {
+        throw new Error('Invalid coordinate value: 999')
+      })
+
+      expect(() => convertCoordinatesToDdm([[[-0.1, 999]]])).toThrow(
+        'Invalid coordinate value: 999'
+      )
+    })
+  })
+})

--- a/src/marine-licences/api/csv/csv-output.js
+++ b/src/marine-licences/api/csv/csv-output.js
@@ -1,5 +1,5 @@
-export const csvOutput = (coordinates) =>
-  coordinates.flatMap((site, index) =>
+export const csvOutput = (coordinates, index) =>
+  coordinates.flatMap((site) =>
     site.map((coord) => [
       coord.latDegree,
       coord.latDecMin,

--- a/src/marine-licences/api/csv/csv-output.js
+++ b/src/marine-licences/api/csv/csv-output.js
@@ -1,16 +1,10 @@
-export const csvOutput = (coordinates) => {
-  const rows = []
-  coordinates.forEach((site, index) => {
-    site.forEach((coord) => {
-      rows.push([
-        coord.latDegree,
-        coord.latDecMin,
-        coord.longDegree,
-        coord.longDecMin,
-        index
-      ])
-    })
-  })
-
-  return rows
-}
+export const csvOutput = (coordinates) =>
+  coordinates.flatMap((site, index) =>
+    site.map((coord) => [
+      coord.latDegree,
+      coord.latDecMin,
+      coord.longDegree,
+      coord.longDecMin,
+      index + 1
+    ])
+  )

--- a/src/marine-licences/api/csv/csv-output.js
+++ b/src/marine-licences/api/csv/csv-output.js
@@ -1,9 +1,14 @@
 export const csvOutput = (coordinates) => {
   const rows = []
-
   coordinates.forEach((site, index) => {
     site.forEach((coordinates) => {
-      rows.push(['', '', '', '', index])
+      rows.push([
+        coordinates.latDegree,
+        coordinates.latDecMin,
+        coordinates.longDegree,
+        coordinates.longDecMin,
+        index
+      ])
     })
   })
 

--- a/src/marine-licences/api/csv/csv-output.js
+++ b/src/marine-licences/api/csv/csv-output.js
@@ -1,0 +1,11 @@
+export const csvOutput = (coordinates) => {
+  const rows = []
+
+  coordinates.forEach((site, index) => {
+    site.forEach((coordinates) => {
+      rows.push(['', '', '', '', index])
+    })
+  })
+
+  return rows
+}

--- a/src/marine-licences/api/csv/csv-output.js
+++ b/src/marine-licences/api/csv/csv-output.js
@@ -1,12 +1,12 @@
 export const csvOutput = (coordinates) => {
   const rows = []
   coordinates.forEach((site, index) => {
-    site.forEach((coordinates) => {
+    site.forEach((coord) => {
       rows.push([
-        coordinates.latDegree,
-        coordinates.latDecMin,
-        coordinates.longDegree,
-        coordinates.longDecMin,
+        coord.latDegree,
+        coord.latDecMin,
+        coord.longDegree,
+        coord.longDecMin,
         index
       ])
     })

--- a/src/marine-licences/api/csv/site-details.js
+++ b/src/marine-licences/api/csv/site-details.js
@@ -1,0 +1,59 @@
+import { generateCirclePolygon } from '../../../shared/common/helpers/emp/transforms/circle-to-polygon.js'
+import { singleOSGB36toWGS84 } from '../../../shared/common/helpers/geo/geo-utils.js'
+import { COORDINATE_SYSTEMS } from '../../../shared/common/constants/coordinates.js'
+
+const { WGS84 } = COORDINATE_SYSTEMS
+
+const circleToCoords = (site) => {
+  const { coordinateSystem, coordinates, circleWidth } = site
+  const radiusMetres = Number.parseInt(circleWidth, 10) / 2
+
+  if (coordinateSystem === WGS84) {
+    return generateCirclePolygon({
+      latitude: Number.parseFloat(coordinates.latitude),
+      longitude: Number.parseFloat(coordinates.longitude),
+      radiusMetres
+    })
+  }
+
+  const [longitude, latitude] = singleOSGB36toWGS84(coordinates)
+  return generateCirclePolygon({ latitude, longitude, radiusMetres })
+}
+
+const polygonToCoords = (site) => {
+  const { coordinateSystem, coordinates } = site
+
+  if (coordinateSystem === WGS84) {
+    return coordinates.map((coord) => [
+      Number.parseFloat(coord.longitude),
+      Number.parseFloat(coord.latitude)
+    ])
+  }
+
+  return coordinates.map((coord) => singleOSGB36toWGS84(coord))
+}
+
+const fileUploadToCoords = (site) =>
+  site.geoJSON.features.map((feature) => feature.geometry.coordinates)
+
+/**
+ * Returns one element per site, preserving site grouping for CSV row generation.
+ * - Circle/polygon sites: WGS84 [lon, lat] coordinate array
+ * - File upload sites: array of coordinate arrays, one per GeoJSON feature
+ */
+export const getSiteCoordinates = (siteDetails = []) =>
+  siteDetails.reduce((acc, site) => {
+    if (site.coordinatesType === 'file') {
+      return [...acc, fileUploadToCoords(site)]
+    }
+
+    if (site.coordinatesEntry === 'single') {
+      return [...acc, circleToCoords(site)]
+    }
+
+    if (site.coordinatesEntry === 'multiple') {
+      return [...acc, polygonToCoords(site)]
+    }
+
+    return acc
+  }, [])

--- a/src/marine-licences/api/csv/site-details.js
+++ b/src/marine-licences/api/csv/site-details.js
@@ -34,7 +34,7 @@ const polygonToCoords = (site) => {
 }
 
 const fileUploadToCoords = (site) =>
-  site.geoJSON.features.map((feature) => feature.geometry.coordinates)
+  site.geoJSON.features.map((feature) => feature.geometry.coordinates[0])
 
 /**
  * Returns one element per site, preserving site grouping for CSV row generation.

--- a/src/marine-licences/api/csv/site-details.js
+++ b/src/marine-licences/api/csv/site-details.js
@@ -1,4 +1,5 @@
 import { generateCirclePolygon } from '../../../shared/common/helpers/emp/transforms/circle-to-polygon.js'
+import { areCoordsTheSame } from '../../../shared/common/helpers/emp/transforms/are-coords-the-same.js'
 import { singleOSGB36toWGS84 } from '../../../shared/common/helpers/geo/geo-utils.js'
 import { COORDINATE_SYSTEMS } from '../../../shared/common/constants/coordinates.js'
 
@@ -23,14 +24,19 @@ const circleToCoords = (site) => {
 const polygonToCoords = (site) => {
   const { coordinateSystem, coordinates } = site
 
-  if (coordinateSystem === WGS84) {
-    return coordinates.map((coord) => [
-      Number.parseFloat(coord.longitude),
-      Number.parseFloat(coord.latitude)
-    ])
+  const coords =
+    coordinateSystem === WGS84
+      ? coordinates.map((coord) => [
+          Number.parseFloat(coord.longitude),
+          Number.parseFloat(coord.latitude)
+        ])
+      : coordinates.map((coord) => singleOSGB36toWGS84(coord))
+
+  if (!areCoordsTheSame(coords[0], coords.at(-1))) {
+    coords.push(coords[0])
   }
 
-  return coordinates.map((coord) => singleOSGB36toWGS84(coord))
+  return coords
 }
 
 const fileUploadToCoords = (site) =>

--- a/src/marine-licences/api/csv/site-details.test.js
+++ b/src/marine-licences/api/csv/site-details.test.js
@@ -1,0 +1,199 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { getSiteCoordinates } from './site-details.js'
+import { generateCirclePolygon } from '../../../shared/common/helpers/emp/transforms/circle-to-polygon.js'
+import { singleOSGB36toWGS84 } from '../../../shared/common/helpers/geo/geo-utils.js'
+
+vi.mock(
+  '../../../shared/common/helpers/emp/transforms/circle-to-polygon.js',
+  () => ({ generateCirclePolygon: vi.fn() })
+)
+
+vi.mock('../../../shared/common/helpers/geo/geo-utils.js', () => ({
+  singleOSGB36toWGS84: vi.fn()
+}))
+
+const mockPolygonRing = [
+  [-0.1, 51.5],
+  [-0.1, 51.501],
+  [-0.099, 51.501],
+  [-0.099, 51.5],
+  [-0.1, 51.5]
+]
+
+const makeCircleSite = (overrides = {}) => ({
+  coordinatesType: 'coordinates',
+  coordinatesEntry: 'single',
+  coordinateSystem: 'wgs84',
+  coordinates: { latitude: '51.5', longitude: '-0.1' },
+  circleWidth: '100',
+  ...overrides
+})
+
+const makePolygonFeature = (ring) => ({
+  type: 'Feature',
+  geometry: { type: 'Polygon', coordinates: [ring] }
+})
+
+const makeFileUploadSite = (...rings) => ({
+  coordinatesType: 'file',
+  geoJSON: {
+    type: 'FeatureCollection',
+    features: rings.map(makePolygonFeature)
+  }
+})
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  generateCirclePolygon.mockReturnValue(mockPolygonRing)
+})
+
+describe('getSiteCoordinates', () => {
+  describe('circle sites', () => {
+    it('returns one entry containing the polygon ring for a WGS84 circle site', () => {
+      const result = getSiteCoordinates([makeCircleSite()])
+
+      expect(generateCirclePolygon).toHaveBeenCalledWith({
+        latitude: 51.5,
+        longitude: -0.1,
+        radiusMetres: 50
+      })
+      expect(result).toHaveLength(1)
+      expect(result[0]).toEqual(mockPolygonRing)
+    })
+
+    it('converts OSGB36 to WGS84 before calling generateCirclePolygon for a circle site', () => {
+      singleOSGB36toWGS84.mockReturnValue([-0.1, 51.5])
+
+      const site = makeCircleSite({
+        coordinateSystem: 'osgb36',
+        coordinates: { easting: '530000', northing: '181000' },
+        circleWidth: '200'
+      })
+
+      const result = getSiteCoordinates([site])
+
+      expect(singleOSGB36toWGS84).toHaveBeenCalledWith(site.coordinates)
+      expect(generateCirclePolygon).toHaveBeenCalledWith({
+        latitude: 51.5,
+        longitude: -0.1,
+        radiusMetres: 100
+      })
+      expect(result).toHaveLength(1)
+      expect(result[0]).toEqual(mockPolygonRing)
+    })
+
+    it('returns one entry per circle site', () => {
+      const result = getSiteCoordinates([
+        makeCircleSite(),
+        makeCircleSite({ coordinates: { latitude: '52.0', longitude: '-1.0' } })
+      ])
+
+      expect(result).toHaveLength(2)
+    })
+  })
+
+  describe('polygon sites', () => {
+    it('returns mapped [lon, lat] pairs for a WGS84 polygon site', () => {
+      const site = {
+        coordinatesType: 'coordinates',
+        coordinatesEntry: 'multiple',
+        coordinateSystem: 'wgs84',
+        coordinates: [
+          { latitude: '51.5', longitude: '-0.1' },
+          { latitude: '51.6', longitude: '-0.2' },
+          { latitude: '51.7', longitude: '-0.3' }
+        ]
+      }
+
+      const result = getSiteCoordinates([site])
+
+      expect(result).toHaveLength(1)
+      expect(result[0]).toEqual([
+        [-0.1, 51.5],
+        [-0.2, 51.6],
+        [-0.3, 51.7]
+      ])
+    })
+
+    it('converts each OSGB36 coordinate to WGS84 for a polygon site', () => {
+      singleOSGB36toWGS84
+        .mockReturnValueOnce([-0.1, 51.5])
+        .mockReturnValueOnce([-0.2, 51.6])
+        .mockReturnValueOnce([-0.3, 51.7])
+
+      const site = {
+        coordinatesType: 'coordinates',
+        coordinatesEntry: 'multiple',
+        coordinateSystem: 'osgb36',
+        coordinates: [
+          { easting: '530000', northing: '181000' },
+          { easting: '530100', northing: '181100' },
+          { easting: '530200', northing: '181200' }
+        ]
+      }
+
+      const result = getSiteCoordinates([site])
+
+      expect(singleOSGB36toWGS84).toHaveBeenCalledTimes(3)
+      expect(result).toHaveLength(1)
+      expect(result[0]).toEqual([
+        [-0.1, 51.5],
+        [-0.2, 51.6],
+        [-0.3, 51.7]
+      ])
+    })
+  })
+
+  describe('file upload sites (coordinatesType === "file")', () => {
+    const ring1 = [
+      [-1.0, 50.0],
+      [-1.0, 51.0],
+      [-2.0, 51.0],
+      [-1.0, 50.0]
+    ]
+    const ring2 = [
+      [-3.0, 52.0],
+      [-3.0, 53.0],
+      [-4.0, 53.0],
+      [-3.0, 52.0]
+    ]
+
+    it('returns one entry for the site containing the feature coordinates', () => {
+      const result = getSiteCoordinates([makeFileUploadSite(ring1)])
+
+      expect(result).toHaveLength(1)
+      expect(result[0]).toEqual([[ring1]])
+    })
+
+    it('returns one entry for the site even when it has multiple features', () => {
+      const result = getSiteCoordinates([makeFileUploadSite(ring1, ring2)])
+
+      expect(result).toHaveLength(1)
+      expect(result[0]).toEqual([[ring1], [ring2]])
+    })
+
+    it('does not call generateCirclePolygon or singleOSGB36toWGS84 for file upload sites', () => {
+      getSiteCoordinates([makeFileUploadSite(ring1)])
+
+      expect(generateCirclePolygon).not.toHaveBeenCalled()
+      expect(singleOSGB36toWGS84).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('edge cases', () => {
+    it.each([
+      ['empty array', []],
+      ['no argument', undefined]
+    ])('returns an empty array when siteDetails is %s', (_, input) => {
+      expect(getSiteCoordinates(input)).toEqual([])
+    })
+
+    it('returns an empty array for a site with an unrecognised coordinatesEntry', () => {
+      expect(
+        getSiteCoordinates([
+          { coordinatesType: 'coordinates', coordinatesEntry: 'unknown' }
+        ])
+      ).toEqual([])
+    })
+  })
+})

--- a/src/marine-licences/api/csv/site-details.test.js
+++ b/src/marine-licences/api/csv/site-details.test.js
@@ -93,7 +93,7 @@ describe('getSiteCoordinates', () => {
   })
 
   describe('polygon sites', () => {
-    it('returns mapped [lon, lat] pairs for a WGS84 polygon site', () => {
+    it('returns mapped [lon, lat] pairs with closing coordinate for a WGS84 polygon site', () => {
       const site = {
         coordinatesType: 'coordinates',
         coordinatesEntry: 'multiple',
@@ -111,11 +111,36 @@ describe('getSiteCoordinates', () => {
       expect(result[0]).toEqual([
         [-0.1, 51.5],
         [-0.2, 51.6],
-        [-0.3, 51.7]
+        [-0.3, 51.7],
+        [-0.1, 51.5]
       ])
     })
 
-    it('converts each OSGB36 coordinate to WGS84 for a polygon site', () => {
+    it('does not duplicate the closing coordinate when the polygon is already closed', () => {
+      const site = {
+        coordinatesType: 'coordinates',
+        coordinatesEntry: 'multiple',
+        coordinateSystem: 'wgs84',
+        coordinates: [
+          { latitude: '51.5', longitude: '-0.1' },
+          { latitude: '51.6', longitude: '-0.2' },
+          { latitude: '51.7', longitude: '-0.3' },
+          { latitude: '51.5', longitude: '-0.1' }
+        ]
+      }
+
+      const result = getSiteCoordinates([site])
+
+      expect(result[0]).toHaveLength(4)
+      expect(result[0]).toEqual([
+        [-0.1, 51.5],
+        [-0.2, 51.6],
+        [-0.3, 51.7],
+        [-0.1, 51.5]
+      ])
+    })
+
+    it('converts each OSGB36 coordinate to WGS84 and closes the polygon', () => {
       singleOSGB36toWGS84
         .mockReturnValueOnce([-0.1, 51.5])
         .mockReturnValueOnce([-0.2, 51.6])
@@ -139,7 +164,8 @@ describe('getSiteCoordinates', () => {
       expect(result[0]).toEqual([
         [-0.1, 51.5],
         [-0.2, 51.6],
-        [-0.3, 51.7]
+        [-0.3, 51.7],
+        [-0.1, 51.5]
       ])
     })
   })

--- a/src/marine-licences/api/csv/site-details.test.js
+++ b/src/marine-licences/api/csv/site-details.test.js
@@ -12,7 +12,7 @@ vi.mock('../../../shared/common/helpers/geo/geo-utils.js', () => ({
   singleOSGB36toWGS84: vi.fn()
 }))
 
-const mockPolygonRing = [
+const mockPolygonFeature = [
   [-0.1, 51.5],
   [-0.1, 51.501],
   [-0.099, 51.501],
@@ -29,27 +29,27 @@ const makeCircleSite = (overrides = {}) => ({
   ...overrides
 })
 
-const makePolygonFeature = (ring) => ({
+const makePolygonFeature = (feature) => ({
   type: 'Feature',
-  geometry: { type: 'Polygon', coordinates: [ring] }
+  geometry: { type: 'Polygon', coordinates: [feature] }
 })
 
-const makeFileUploadSite = (...rings) => ({
+const makeFileUploadSite = (...features) => ({
   coordinatesType: 'file',
   geoJSON: {
     type: 'FeatureCollection',
-    features: rings.map(makePolygonFeature)
+    features: features.map(makePolygonFeature)
   }
 })
 
 beforeEach(() => {
   vi.clearAllMocks()
-  generateCirclePolygon.mockReturnValue(mockPolygonRing)
+  generateCirclePolygon.mockReturnValue(mockPolygonFeature)
 })
 
 describe('getSiteCoordinates', () => {
   describe('circle sites', () => {
-    it('returns one entry containing the polygon ring for a WGS84 circle site', () => {
+    it('returns one entry containing the polygon feature for a WGS84 circle site', () => {
       const result = getSiteCoordinates([makeCircleSite()])
 
       expect(generateCirclePolygon).toHaveBeenCalledWith({
@@ -58,7 +58,7 @@ describe('getSiteCoordinates', () => {
         radiusMetres: 50
       })
       expect(result).toHaveLength(1)
-      expect(result[0]).toEqual(mockPolygonRing)
+      expect(result[0]).toEqual(mockPolygonFeature)
     })
 
     it('converts OSGB36 to WGS84 before calling generateCirclePolygon for a circle site', () => {
@@ -79,7 +79,7 @@ describe('getSiteCoordinates', () => {
         radiusMetres: 100
       })
       expect(result).toHaveLength(1)
-      expect(result[0]).toEqual(mockPolygonRing)
+      expect(result[0]).toEqual(mockPolygonFeature)
     })
 
     it('returns one entry per circle site', () => {
@@ -145,35 +145,37 @@ describe('getSiteCoordinates', () => {
   })
 
   describe('file upload sites (coordinatesType === "file")', () => {
-    const ring1 = [
+    const feature1 = [
       [-1.0, 50.0],
       [-1.0, 51.0],
       [-2.0, 51.0],
       [-1.0, 50.0]
     ]
-    const ring2 = [
+    const feature2 = [
       [-3.0, 52.0],
       [-3.0, 53.0],
       [-4.0, 53.0],
       [-3.0, 52.0]
     ]
 
-    it('returns one entry for the site containing the feature coordinates', () => {
-      const result = getSiteCoordinates([makeFileUploadSite(ring1)])
+    it('returns one entry for the site containing the outer feature coordinates', () => {
+      const result = getSiteCoordinates([makeFileUploadSite(feature1)])
 
       expect(result).toHaveLength(1)
-      expect(result[0]).toEqual([[ring1]])
+      expect(result[0]).toEqual([feature1])
     })
 
     it('returns one entry for the site even when it has multiple features', () => {
-      const result = getSiteCoordinates([makeFileUploadSite(ring1, ring2)])
+      const result = getSiteCoordinates([
+        makeFileUploadSite(feature1, feature2)
+      ])
 
       expect(result).toHaveLength(1)
-      expect(result[0]).toEqual([[ring1], [ring2]])
+      expect(result[0]).toEqual([feature1, feature2])
     })
 
     it('does not call generateCirclePolygon or singleOSGB36toWGS84 for file upload sites', () => {
-      getSiteCoordinates([makeFileUploadSite(ring1)])
+      getSiteCoordinates([makeFileUploadSite(feature1)])
 
       expect(generateCirclePolygon).not.toHaveBeenCalled()
       expect(singleOSGB36toWGS84).not.toHaveBeenCalled()

--- a/src/marine-licences/api/index.js
+++ b/src/marine-licences/api/index.js
@@ -12,6 +12,7 @@ import { updateSiteDetailsController } from './controllers/update-site-details.j
 import { addActivityDetailsController } from './controllers/add-activity-details.js'
 import { deleteActivityDetailsController } from './controllers/delete-activity-details.js'
 import { updateSiteController } from './controllers/update-site.js'
+import { generateCoordinatesCsvController } from './controllers/generate-coordinates-csv.js'
 
 export const marineLicences = [
   {
@@ -88,5 +89,10 @@ export const marineLicences = [
     method: 'PATCH',
     path: '/marine-licence/public-consultation',
     ...updatePublicConsultationController
+  },
+  {
+    method: 'GET',
+    path: '/marine-licence/{id}/generate-coordinates-csv',
+    ...generateCoordinatesCsvController
   }
 ]

--- a/src/shared/common/helpers/geo/geo-transforms.js
+++ b/src/shared/common/helpers/geo/geo-transforms.js
@@ -42,6 +42,13 @@ const DIRECTIONS = {
   west: 'W'
 }
 
+const getDirection = (coordinate, isLatitude) => {
+  if (isLatitude) {
+    return coordinate >= 0 ? DIRECTIONS.north : DIRECTIONS.south
+  }
+  return coordinate >= 0 ? DIRECTIONS.east : DIRECTIONS.west
+}
+
 /**
  * Convert WGS84 to Degrees Decimal Minutes format
  *
@@ -67,14 +74,7 @@ export const coordinatesToDegreesDecimalMinutes = (coordinate, isLatitude) => {
   const minutes = ((absolute - degrees) * MINUTES_PER_DEGREE).toFixed(
     MINUTES_DECIMAL_PLACES
   )
-  const isPositive = coordinate >= 0
-  const direction = isLatitude
-    ? isPositive
-      ? DIRECTIONS.north
-      : DIRECTIONS.south
-    : isPositive
-      ? DIRECTIONS.east
-      : DIRECTIONS.west
+  const direction = getDirection(coordinate, isLatitude)
 
   const paddedDegrees = String(degrees).padStart(DEGREE_PAD_LENGTH, '0')
   const paddedMinutes = minutes.padStart(MINUTES_PAD_LENGTH, '0')

--- a/src/shared/common/helpers/geo/geo-transforms.js
+++ b/src/shared/common/helpers/geo/geo-transforms.js
@@ -31,7 +31,7 @@ export const formatGeoForStorage = (geoJson) => {
 /**
  * Convert WGS84 to Degrees Decimal Minutes format
  *
- * @param {string} coordinate - coordinate to convert
+ * @param {number} coordinate - coordinate to convert
  * @param {boolean} isLatitude - is this a latitude value
 
  */

--- a/src/shared/common/helpers/geo/geo-transforms.js
+++ b/src/shared/common/helpers/geo/geo-transforms.js
@@ -27,3 +27,37 @@ export const formatGeoForStorage = (geoJson) => {
     properties: feature.properties
   }))
 }
+
+/**
+ * Convert WGS84 to Degrees Decimal Minutes format
+ *
+ * @param {string} coordinate - coordinate to convert
+ * @param {boolean} isLatitude - is this a latitude value
+
+ */
+export const coordinatesToDegreesDecimalMinutes = (coordinate, isLatitude) => {
+  if (isNaN(coordinate) || coordinate < -180 || coordinate > 180) {
+    throw new Error(`Invalid coordinate value: ${coordinate}`)
+  }
+  if (isLatitude && (coordinate < -90 || coordinate > 90)) {
+    throw new Error(`Latitude out of range: ${coordinate}`)
+  }
+
+  // Remove the minus sign so the maths works correctly; we track N/S/E/W separately
+  const absolute = Math.abs(coordinate)
+
+  const degrees = Math.floor(absolute)
+  const minutes = ((absolute - degrees) * 60).toFixed(4)
+  const direction = isLatitude
+    ? coordinate >= 0
+      ? 'N'
+      : 'S'
+    : coordinate >= 0
+      ? 'E'
+      : 'W'
+
+  const paddedDegrees = String(degrees).padStart(2, '0')
+  const paddedMinutes = minutes.padStart(7, '0')
+
+  return `${paddedDegrees}° ${paddedMinutes}' ${direction}`
+}

--- a/src/shared/common/helpers/geo/geo-transforms.js
+++ b/src/shared/common/helpers/geo/geo-transforms.js
@@ -28,18 +28,35 @@ export const formatGeoForStorage = (geoJson) => {
   }))
 }
 
+const LONGITUDE_MAX = 180
+const LATITUDE_MAX = 90
+const MINUTES_PER_DEGREE = 60
+const MINUTES_DECIMAL_PLACES = 4
+const DEGREE_PAD_LENGTH = 2
+const MINUTES_PAD_LENGTH = 7
+
+const DIRECTIONS = {
+  north: 'N',
+  south: 'S',
+  east: 'E',
+  west: 'W'
+}
+
 /**
  * Convert WGS84 to Degrees Decimal Minutes format
  *
  * @param {number} coordinate - coordinate to convert
  * @param {boolean} isLatitude - is this a latitude value
-
  */
 export const coordinatesToDegreesDecimalMinutes = (coordinate, isLatitude) => {
-  if (isNaN(coordinate) || coordinate < -180 || coordinate > 180) {
+  if (
+    Number.isNaN(coordinate) ||
+    coordinate < -LONGITUDE_MAX ||
+    coordinate > LONGITUDE_MAX
+  ) {
     throw new Error(`Invalid coordinate value: ${coordinate}`)
   }
-  if (isLatitude && (coordinate < -90 || coordinate > 90)) {
+  if (isLatitude && (coordinate < -LATITUDE_MAX || coordinate > LATITUDE_MAX)) {
     throw new Error(`Latitude out of range: ${coordinate}`)
   }
 
@@ -47,17 +64,20 @@ export const coordinatesToDegreesDecimalMinutes = (coordinate, isLatitude) => {
   const absolute = Math.abs(coordinate)
 
   const degrees = Math.floor(absolute)
-  const minutes = ((absolute - degrees) * 60).toFixed(4)
+  const minutes = ((absolute - degrees) * MINUTES_PER_DEGREE).toFixed(
+    MINUTES_DECIMAL_PLACES
+  )
+  const isPositive = coordinate >= 0
   const direction = isLatitude
-    ? coordinate >= 0
-      ? 'N'
-      : 'S'
-    : coordinate >= 0
-      ? 'E'
-      : 'W'
+    ? isPositive
+      ? DIRECTIONS.north
+      : DIRECTIONS.south
+    : isPositive
+      ? DIRECTIONS.east
+      : DIRECTIONS.west
 
-  const paddedDegrees = String(degrees).padStart(2, '0')
-  const paddedMinutes = minutes.padStart(7, '0')
+  const paddedDegrees = String(degrees).padStart(DEGREE_PAD_LENGTH, '0')
+  const paddedMinutes = minutes.padStart(MINUTES_PAD_LENGTH, '0')
 
   return `${paddedDegrees}° ${paddedMinutes}' ${direction}`
 }

--- a/src/shared/common/helpers/geo/geo-transforms.js
+++ b/src/shared/common/helpers/geo/geo-transforms.js
@@ -1,3 +1,4 @@
+import Boom from '@hapi/boom'
 import { buffer } from '@turf/turf'
 
 const coastalAreasLabelProperty = 'marine_are'
@@ -56,18 +57,22 @@ const getDirection = (coordinate, isLatitude) => {
  * @param {boolean} isLatitude - is this a latitude value
  */
 export const coordinatesToDegreesDecimalMinutes = (coordinate, isLatitude) => {
-  if (
-    Number.isNaN(coordinate) ||
-    coordinate < -LONGITUDE_MAX ||
-    coordinate > LONGITUDE_MAX
-  ) {
-    throw new Error(`Invalid coordinate value: ${coordinate}`)
-  }
-  if (isLatitude && (coordinate < -LATITUDE_MAX || coordinate > LATITUDE_MAX)) {
-    throw new Error(`Latitude out of range: ${coordinate}`)
+  if (typeof coordinate !== 'number') {
+    throw Boom.internal(`Invalid coordinate value: ${coordinate}`)
   }
 
-  // Remove the minus sign so the maths works correctly; we track N/S/E/W separately
+  if (
+    !isLatitude &&
+    (coordinate < -LONGITUDE_MAX || coordinate > LONGITUDE_MAX)
+  ) {
+    throw Boom.internal(`Longitude out of range: ${coordinate}`)
+  }
+
+  if (isLatitude && (coordinate < -LATITUDE_MAX || coordinate > LATITUDE_MAX)) {
+    throw Boom.internal(`Latitude out of range: ${coordinate}`)
+  }
+
+  // Remove the minus sign so the maths works correctly
   const absolute = Math.abs(coordinate)
 
   const degrees = Math.floor(absolute)

--- a/src/shared/common/helpers/geo/geo-transforms.test.js
+++ b/src/shared/common/helpers/geo/geo-transforms.test.js
@@ -1,5 +1,8 @@
 import { describe, it, expect } from 'vitest'
-import { formatGeoForStorage } from './geo-transforms.js'
+import {
+  coordinatesToDegreesDecimalMinutes,
+  formatGeoForStorage
+} from './geo-transforms.js'
 import { mockFeatureCollection } from './test.fixture.js'
 
 describe('geo-transforms', () => {
@@ -47,5 +50,26 @@ describe('geo-transforms', () => {
         type: 'Feature'
       })
     })
+  })
+  describe('coordinatesToDegreesDecimalMinutes', () => {
+    it.each([
+      [53.386185, true, `53° 23.1711' N`],
+      [-3.007353, false, `03° 00.4412' W`],
+      [53.4808, true, `53° 28.8480' N`],
+      [-2.2426005, false, `02° 14.5560' W`],
+      [55.9533, true, `55° 57.1980' N`],
+      [-3.188355, false, `03° 11.3013' W`],
+      [51.4816, true, `51° 28.8960' N`],
+      [-3.179151, false, `03° 10.7491' W`]
+    ])(
+      'should correctly convert %s to Degrees Decimal Minutes format',
+      (coordinateInput, isLatitude, expectedResult) => {
+        const result = coordinatesToDegreesDecimalMinutes(
+          coordinateInput,
+          isLatitude
+        )
+        expect(result).toEqual(expectedResult)
+      }
+    )
   })
 })

--- a/src/shared/common/helpers/geo/geo-transforms.test.js
+++ b/src/shared/common/helpers/geo/geo-transforms.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, expect } from 'vitest'
 import {
   coordinatesToDegreesDecimalMinutes,
   formatGeoForStorage
@@ -7,7 +7,7 @@ import { mockFeatureCollection } from './test.fixture.js'
 
 describe('geo-transforms', () => {
   describe('formatGeoForStorage', () => {
-    it('should correctly format all data for Marine Plan Areas', () => {
+    test('should correctly format all data for Marine Plan Areas', () => {
       const formattedGeoData = formatGeoForStorage(mockFeatureCollection)
 
       expect(formattedGeoData.length).toBe(2)
@@ -27,7 +27,7 @@ describe('geo-transforms', () => {
       })
     })
 
-    it('should correctly format all data for Coastal Operations Areas', () => {
+    test('should correctly format all data for Coastal Operations Areas', () => {
       const mockCoastalAreasCollection = {
         ...mockFeatureCollection,
         features: mockFeatureCollection.features.map((area) => {
@@ -52,7 +52,7 @@ describe('geo-transforms', () => {
     })
   })
   describe('coordinatesToDegreesDecimalMinutes', () => {
-    it.each([
+    test.each([
       [53.386185, true, `53° 23.1711' N`],
       [-3.007353, false, `03° 00.4412' W`],
       [53.4808, true, `53° 28.8480' N`],
@@ -60,7 +60,9 @@ describe('geo-transforms', () => {
       [55.9533, true, `55° 57.1980' N`],
       [-3.188355, false, `03° 11.3013' W`],
       [51.4816, true, `51° 28.8960' N`],
-      [-3.179151, false, `03° 10.7491' W`]
+      [-3.179151, false, `03° 10.7491' W`],
+      [-33.8688, true, `33° 52.1280' S`],
+      [1.2974, false, `01° 17.8440' E`]
     ])(
       'should correctly convert %s to Degrees Decimal Minutes format',
       (coordinateInput, isLatitude, expectedResult) => {
@@ -71,5 +73,36 @@ describe('geo-transforms', () => {
         expect(result).toEqual(expectedResult)
       }
     )
+
+    test('correctly errors on invalid coordinate values', () => {
+      const invalidNumber = 'abc'
+      expect(() =>
+        coordinatesToDegreesDecimalMinutes(invalidNumber, false)
+      ).toThrow('Invalid coordinate value: abc')
+    })
+
+    test('correctly errors on lng coordinate values below minimum', () => {
+      expect(() => coordinatesToDegreesDecimalMinutes(-190, false)).toThrow(
+        'Longitude out of range: -190'
+      )
+    })
+
+    test('correctly errors on lng coordinate values below minimum', () => {
+      expect(() => coordinatesToDegreesDecimalMinutes(190, false)).toThrow(
+        'Longitude out of range: 190'
+      )
+    })
+
+    test('correctly errors on lat coordinate values below minimum', () => {
+      expect(() => coordinatesToDegreesDecimalMinutes(-190, true)).toThrow(
+        'Latitude out of range: -190'
+      )
+    })
+
+    test('correctly errors on lat coordinate values below minimum', () => {
+      expect(() => coordinatesToDegreesDecimalMinutes(190, true)).toThrow(
+        'Latitude out of range: 190'
+      )
+    })
   })
 })

--- a/src/shared/helpers/is-entra-id-user.js
+++ b/src/shared/helpers/is-entra-id-user.js
@@ -1,0 +1,6 @@
+import { getJwtAuthStrategy } from '../plugins/auth.js'
+
+export const isEntraIdUser = (request) => {
+  const authStrategy = getJwtAuthStrategy(request.auth?.artifacts?.decoded)
+  return authStrategy === 'entraId'
+}

--- a/src/shared/helpers/is-entra-id-user.test.js
+++ b/src/shared/helpers/is-entra-id-user.test.js
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import { isEntraIdUser } from './is-entra-id-user.js'
 
-describe('isApplicantUser', () => {
+describe('isEntraIdUser', () => {
   it('returns true when the decoded JWT is Entra ID user', () => {
     const request = { auth: { artifacts: { decoded: { tid: 'tenant-id' } } } }
     expect(isEntraIdUser(request)).toBe(true)

--- a/src/shared/helpers/is-entra-id-user.test.js
+++ b/src/shared/helpers/is-entra-id-user.test.js
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest'
+import { isEntraIdUser } from './is-entra-id-user.js'
+
+describe('isApplicantUser', () => {
+  it('returns true when the decoded JWT is Entra ID user', () => {
+    const request = { auth: { artifacts: { decoded: { tid: 'tenant-id' } } } }
+    expect(isEntraIdUser(request)).toBe(true)
+  })
+
+  it('returns false when the decoded JWT is an applicant user', () => {
+    const request = { auth: { artifacts: { decoded: { sub: 'user-id' } } } }
+    expect(isEntraIdUser(request)).toBe(false)
+  })
+
+  it('returns false when auth artifacts are missing', () => {
+    const request = { auth: {} }
+    expect(isEntraIdUser(request)).toBe(false)
+  })
+})


### PR DESCRIPTION
## Description
 
Convert Site Details into a CSV for Entra ID users to download.

Conversion to Decimal Degrees Minutes format is required.
 
## Changes
 
- New route` 'generate-coordinates-csv'` which is for Entra ID users only.

- `convertCoordinatesToDdm`: Convert all the coordinates into Decimal Degrees Minutes using `coordinatesToDegreesDecimalMinutes`. This format looks like: `53° 23.1711, -3° 0.4412`

- Use `coordinatesToCsvObject` to split this into an object for the CSV, with latDegree, latDecMin, longDegre, longDecMin as the properties.

- `csvOutput` will loop through and add these properties to rows in the CSV. objectid in this context is to group coordinates by the site.