### PR TITLE
ML-1292 Add exemption reporting metrics to admin summary report

### DIFF
--- a/src/exemptions/api/controllers/get-exemption-summary.integration.test.js
+++ b/src/exemptions/api/controllers/get-exemption-summary.integration.test.js
@@ -22,6 +22,34 @@ describe('Get exemption summary - integration tests', () => {
     await globalThis.mockMongo.collection(collectionExemptions).deleteMany({})
   })
 
+  test('returns zero counts when no exemptions exist', async () => {
+    const { statusCode, body } = await makeGetRequest({
+      server,
+      url: '/exemptions/summary',
+      isInternalUser: true
+    })
+
+    expect(statusCode).toBe(200)
+    expect(body).toEqual({
+      submittedExemptions: 0,
+      unsubmittedExemptions: 0,
+      withdrawnExemptions: 0,
+      coordinatesInputMethod: {
+        shapefile: 0,
+        kml: 0,
+        manualCoordinates: 0
+      },
+      coordinateSystemVolume: {
+        wgs84: { count: 0, percentage: 0 },
+        bng: { count: 0, percentage: 0 },
+        total: 0
+      },
+      byArticle: {},
+      byMarinePlanArea: {},
+      byCoastalOperationsArea: {}
+    })
+  })
+
   test('returns aggregated counts for internal users', async () => {
     const exemptions = [
       createCompleteExemption({

--- a/src/exemptions/api/controllers/get-exemption-summary.integration.test.js
+++ b/src/exemptions/api/controllers/get-exemption-summary.integration.test.js
@@ -2,6 +2,7 @@ import { makeGetRequest } from '../../../../tests/server-requests.js'
 import { createCompleteExemption } from '../../../../tests/test.fixture.js'
 import { EXEMPTION_STATUS } from '../../constants/exemption.js'
 import { collectionExemptions } from '../../../shared/common/constants/db-collections.js'
+import { COORDINATE_SYSTEMS } from '../../../shared/common/constants/coordinates.js'
 import { ObjectId } from 'mongodb'
 
 describe('Get exemption summary - integration tests', () => {
@@ -25,23 +26,127 @@ describe('Get exemption summary - integration tests', () => {
     const exemptions = [
       createCompleteExemption({
         _id: new ObjectId(),
-        status: EXEMPTION_STATUS.ACTIVE
+        status: EXEMPTION_STATUS.ACTIVE,
+        mcmsContext: { articleCode: '25' },
+        marinePlanAreas: ['East inshore'],
+        coastalOperationsAreas: ['South'],
+        siteDetails: [
+          {
+            coordinatesType: 'file',
+            fileUploadType: 'shapefile',
+            geoJSON: {
+              type: 'FeatureCollection',
+              features: [
+                {
+                  type: 'Feature',
+                  geometry: {
+                    type: 'Point',
+                    coordinates: [1.076016, 51.474968]
+                  },
+                  properties: {}
+                }
+              ]
+            },
+            featureCount: 1,
+            uploadedFile: { filename: 'site.shp' },
+            s3Location: {
+              s3Bucket: 'bucket',
+              s3Key: 'key',
+              checksumSha256: 'checksum'
+            },
+            activityDates: {
+              start: new Date('2027-01-01'),
+              end: new Date('2027-12-31')
+            },
+            activityDescription: 'Shapefile activity'
+          }
+        ]
       }),
       createCompleteExemption({
         _id: new ObjectId(),
-        status: EXEMPTION_STATUS.ACTIVE
+        status: EXEMPTION_STATUS.ACTIVE,
+        mcmsContext: { articleCode: '17' },
+        marinePlanAreas: ['East inshore', 'South inshore'],
+        coastalOperationsAreas: ['South East'],
+        siteDetails: [
+          {
+            coordinatesType: 'file',
+            fileUploadType: 'kml',
+            geoJSON: {
+              type: 'FeatureCollection',
+              features: [
+                {
+                  type: 'Feature',
+                  geometry: {
+                    type: 'Point',
+                    coordinates: [1.076016, 51.474968]
+                  },
+                  properties: {}
+                }
+              ]
+            },
+            featureCount: 1,
+            uploadedFile: { filename: 'site.kml' },
+            s3Location: {
+              s3Bucket: 'bucket',
+              s3Key: 'key-2',
+              checksumSha256: 'checksum-2'
+            },
+            activityDates: {
+              start: new Date('2027-01-01'),
+              end: new Date('2027-12-31')
+            },
+            activityDescription: 'KML activity'
+          }
+        ]
       }),
       createCompleteExemption({
         _id: new ObjectId(),
-        status: EXEMPTION_STATUS.SUBMITTED
+        status: EXEMPTION_STATUS.SUBMITTED,
+        mcmsContext: { articleCode: '25' },
+        siteDetails: [
+          {
+            coordinatesType: 'coordinates',
+            coordinatesEntry: 'single',
+            coordinateSystem: COORDINATE_SYSTEMS.OSGB36,
+            coordinates: {
+              easting: '500000',
+              northing: '150000'
+            },
+            circleWidth: '20',
+            activityDates: {
+              start: new Date('2027-01-01'),
+              end: new Date('2027-12-31')
+            },
+            activityDescription: 'Manual BNG activity'
+          }
+        ]
       }),
       createCompleteExemption({
         _id: new ObjectId(),
-        status: EXEMPTION_STATUS.DRAFT
+        status: EXEMPTION_STATUS.DRAFT,
+        siteDetails: [
+          {
+            coordinatesType: 'coordinates',
+            coordinatesEntry: 'single',
+            coordinateSystem: COORDINATE_SYSTEMS.WGS84,
+            coordinates: {
+              latitude: '51.489676',
+              longitude: '-0.231530'
+            },
+            circleWidth: '20',
+            activityDates: {
+              start: new Date('2027-01-01'),
+              end: new Date('2027-12-31')
+            },
+            activityDescription: 'Draft manual WGS84 activity'
+          }
+        ]
       }),
       createCompleteExemption({
         _id: new ObjectId(),
-        status: EXEMPTION_STATUS.WITHDRAWN
+        status: EXEMPTION_STATUS.WITHDRAWN,
+        siteDetails: []
       })
     ]
 
@@ -59,7 +164,29 @@ describe('Get exemption summary - integration tests', () => {
     expect(body).toEqual({
       submittedExemptions: 3,
       unsubmittedExemptions: 1,
-      withdrawnExemptions: 1
+      withdrawnExemptions: 1,
+      coordinatesInputMethod: {
+        shapefile: 1,
+        kml: 1,
+        manualCoordinates: 2
+      },
+      coordinateSystemVolume: {
+        wgs84: { count: 3, percentage: 75 },
+        bng: { count: 1, percentage: 25 },
+        total: 4
+      },
+      byArticle: {
+        25: 2,
+        17: 1
+      },
+      byMarinePlanArea: {
+        'East inshore': 2,
+        'South inshore': 1
+      },
+      byCoastalOperationsArea: {
+        South: 1,
+        'South East': 1
+      }
     })
   })
 })

--- a/src/exemptions/api/controllers/get-exemption-summary.integration.test.js
+++ b/src/exemptions/api/controllers/get-exemption-summary.integration.test.js
@@ -168,12 +168,12 @@ describe('Get exemption summary - integration tests', () => {
       coordinatesInputMethod: {
         shapefile: 1,
         kml: 1,
-        manualCoordinates: 2
+        manualCoordinates: 1
       },
       coordinateSystemVolume: {
-        wgs84: { count: 3, percentage: 75 },
-        bng: { count: 1, percentage: 25 },
-        total: 4
+        wgs84: { count: 2, percentage: 66.7 },
+        bng: { count: 1, percentage: 33.3 },
+        total: 3
       },
       byArticle: {
         25: 2,

--- a/src/exemptions/api/controllers/get-exemption-summary.js
+++ b/src/exemptions/api/controllers/get-exemption-summary.js
@@ -2,48 +2,24 @@ import Boom from '@hapi/boom'
 import { StatusCodes } from 'http-status-codes'
 import { collectionExemptions } from '../../../shared/common/constants/db-collections.js'
 import { structureErrorForECS } from '../../../shared/common/helpers/logging/logger.js'
-import { EXEMPTION_STATUS } from '../../constants/exemption.js'
+import {
+  buildExemptionSummaryPipeline,
+  buildExemptionSummaryValue
+} from '../helpers/exemption-summary.js'
 
 export const getExemptionSummaryController = {
   handler: async (request, h) => {
     try {
       const { db } = request
-      const groupedStatusCounts = await db
+      const [summaryResult] = await db
         .collection(collectionExemptions)
-        .aggregate([
-          {
-            $match: {
-              status: {
-                $in: [
-                  EXEMPTION_STATUS.ACTIVE,
-                  EXEMPTION_STATUS.SUBMITTED,
-                  EXEMPTION_STATUS.DRAFT,
-                  EXEMPTION_STATUS.WITHDRAWN
-                ]
-              }
-            }
-          },
-          { $group: { _id: '$status', count: { $sum: 1 } } }
-        ])
+        .aggregate(buildExemptionSummaryPipeline())
         .toArray()
-
-      const countsByStatus = groupedStatusCounts.reduce((acc, item) => {
-        acc[item._id] = item.count
-        return acc
-      }, {})
-
-      const submittedExemptions =
-        (countsByStatus[EXEMPTION_STATUS.ACTIVE] ?? 0) +
-        (countsByStatus[EXEMPTION_STATUS.SUBMITTED] ?? 0)
 
       return h
         .response({
           message: 'success',
-          value: {
-            submittedExemptions,
-            unsubmittedExemptions: countsByStatus[EXEMPTION_STATUS.DRAFT] ?? 0,
-            withdrawnExemptions: countsByStatus[EXEMPTION_STATUS.WITHDRAWN] ?? 0
-          }
+          value: buildExemptionSummaryValue(summaryResult)
         })
         .code(StatusCodes.OK)
     } catch (error) {

--- a/src/exemptions/api/controllers/get-exemption-summary.js
+++ b/src/exemptions/api/controllers/get-exemption-summary.js
@@ -4,7 +4,8 @@ import { collectionExemptions } from '../../../shared/common/constants/db-collec
 import { structureErrorForECS } from '../../../shared/common/helpers/logging/logger.js'
 import {
   buildExemptionSummaryPipeline,
-  buildExemptionSummaryValue
+  buildExemptionSummaryValue,
+  EMPTY_EXEMPTION_SUMMARY_FACET
 } from '../helpers/exemption-summary.js'
 
 export const getExemptionSummaryController = {
@@ -19,7 +20,9 @@ export const getExemptionSummaryController = {
       return h
         .response({
           message: 'success',
-          value: buildExemptionSummaryValue(summaryResult)
+          value: buildExemptionSummaryValue(
+            summaryResult ?? EMPTY_EXEMPTION_SUMMARY_FACET
+          )
         })
         .code(StatusCodes.OK)
     } catch (error) {

--- a/src/exemptions/api/controllers/get-exemption-summary.test.js
+++ b/src/exemptions/api/controllers/get-exemption-summary.test.js
@@ -1,6 +1,7 @@
 import { vi, expect } from 'vitest'
 import Boom from '@hapi/boom'
 import { getExemptionSummaryController } from './get-exemption-summary.js'
+import { buildExemptionSummaryPipeline } from '../helpers/exemption-summary.js'
 import { EXEMPTION_STATUS } from '../../constants/exemption.js'
 
 describe('GET /exemptions/summary', () => {
@@ -20,15 +21,29 @@ describe('GET /exemptions/summary', () => {
     }
   })
 
-  it('returns status counts for internal users', async () => {
+  it('returns status counts and report metrics for internal users', async () => {
     mockDb = {
       collection: vi.fn().mockReturnValue({
         aggregate: mockAggregate.mockReturnValue({
           toArray: vi.fn().mockResolvedValue([
-            { _id: EXEMPTION_STATUS.ACTIVE, count: 4 },
-            { _id: EXEMPTION_STATUS.SUBMITTED, count: 2 },
-            { _id: EXEMPTION_STATUS.DRAFT, count: 3 },
-            { _id: EXEMPTION_STATUS.WITHDRAWN, count: 1 }
+            {
+              statusCounts: [
+                { _id: EXEMPTION_STATUS.ACTIVE, count: 4 },
+                { _id: EXEMPTION_STATUS.SUBMITTED, count: 2 },
+                { _id: EXEMPTION_STATUS.DRAFT, count: 3 },
+                { _id: EXEMPTION_STATUS.WITHDRAWN, count: 1 }
+              ],
+              shapefileExemptions: [{ count: 1 }],
+              kmlExemptions: [{ count: 2 }],
+              manualCoordinatesExemptions: [{ count: 3 }],
+              coordinateSystemVolume: [
+                { _id: 'wgs84', count: 4 },
+                { _id: 'osgb36', count: 1 }
+              ],
+              byArticle: [{ _id: '25', count: 2 }],
+              byMarinePlanArea: [{ _id: 'East inshore', count: 1 }],
+              byCoastalOperationsArea: [{ _id: 'South', count: 1 }]
+            }
           ])
         })
       })
@@ -47,32 +62,48 @@ describe('GET /exemptions/summary', () => {
       value: {
         submittedExemptions: 6,
         unsubmittedExemptions: 3,
-        withdrawnExemptions: 1
+        withdrawnExemptions: 1,
+        coordinatesInputMethod: {
+          shapefile: 1,
+          kml: 2,
+          manualCoordinates: 3
+        },
+        coordinateSystemVolume: {
+          wgs84: { count: 4, percentage: 80 },
+          bng: { count: 1, percentage: 20 },
+          total: 5
+        },
+        byArticle: {
+          25: 2
+        },
+        byMarinePlanArea: {
+          'East inshore': 1
+        },
+        byCoastalOperationsArea: {
+          South: 1
+        }
       }
     })
     expect(mockHandler.code).toHaveBeenCalledWith(200)
-    expect(mockAggregate).toHaveBeenCalledWith([
-      {
-        $match: {
-          status: {
-            $in: [
-              EXEMPTION_STATUS.ACTIVE,
-              EXEMPTION_STATUS.SUBMITTED,
-              EXEMPTION_STATUS.DRAFT,
-              EXEMPTION_STATUS.WITHDRAWN
-            ]
-          }
-        }
-      },
-      { $group: { _id: '$status', count: { $sum: 1 } } }
-    ])
+    expect(mockAggregate).toHaveBeenCalledWith(buildExemptionSummaryPipeline())
   })
 
   it('returns zero counts when statuses are missing', async () => {
     mockDb = {
       collection: vi.fn().mockReturnValue({
         aggregate: vi.fn().mockReturnValue({
-          toArray: vi.fn().mockResolvedValue([])
+          toArray: vi.fn().mockResolvedValue([
+            {
+              statusCounts: [],
+              shapefileExemptions: [],
+              kmlExemptions: [],
+              manualCoordinatesExemptions: [],
+              coordinateSystemVolume: [],
+              byArticle: [],
+              byMarinePlanArea: [],
+              byCoastalOperationsArea: []
+            }
+          ])
         })
       })
     }
@@ -90,7 +121,20 @@ describe('GET /exemptions/summary', () => {
       value: {
         submittedExemptions: 0,
         unsubmittedExemptions: 0,
-        withdrawnExemptions: 0
+        withdrawnExemptions: 0,
+        coordinatesInputMethod: {
+          shapefile: 0,
+          kml: 0,
+          manualCoordinates: 0
+        },
+        coordinateSystemVolume: {
+          wgs84: { count: 0, percentage: 0 },
+          bng: { count: 0, percentage: 0 },
+          total: 0
+        },
+        byArticle: {},
+        byMarinePlanArea: {},
+        byCoastalOperationsArea: {}
       }
     })
   })

--- a/src/exemptions/api/controllers/get-exemption-summary.test.js
+++ b/src/exemptions/api/controllers/get-exemption-summary.test.js
@@ -88,6 +88,46 @@ describe('GET /exemptions/summary', () => {
     expect(mockAggregate).toHaveBeenCalledWith(buildExemptionSummaryPipeline())
   })
 
+  it('returns zero counts when aggregation returns no documents', async () => {
+    mockDb = {
+      collection: vi.fn().mockReturnValue({
+        aggregate: vi.fn().mockReturnValue({
+          toArray: vi.fn().mockResolvedValue([])
+        })
+      })
+    }
+
+    const request = {
+      db: mockDb,
+      auth: { artifacts: { decoded: { tid: 'entra-tenant-id' } } },
+      logger: mockLogger
+    }
+
+    await getExemptionSummaryController.handler(request, mockHandler)
+
+    expect(mockHandler.response).toHaveBeenCalledWith({
+      message: 'success',
+      value: {
+        submittedExemptions: 0,
+        unsubmittedExemptions: 0,
+        withdrawnExemptions: 0,
+        coordinatesInputMethod: {
+          shapefile: 0,
+          kml: 0,
+          manualCoordinates: 0
+        },
+        coordinateSystemVolume: {
+          wgs84: { count: 0, percentage: 0 },
+          bng: { count: 0, percentage: 0 },
+          total: 0
+        },
+        byArticle: {},
+        byMarinePlanArea: {},
+        byCoastalOperationsArea: {}
+      }
+    })
+  })
+
   it('returns zero counts when statuses are missing', async () => {
     mockDb = {
       collection: vi.fn().mockReturnValue({

--- a/src/exemptions/api/helpers/exemption-summary.js
+++ b/src/exemptions/api/helpers/exemption-summary.js
@@ -73,6 +73,17 @@ const buildReportingFacets = () => ({
   byCoastalOperationsArea: groupByFieldFacet('coastalOperationsAreas')
 })
 
+export const EMPTY_EXEMPTION_SUMMARY_FACET = {
+  statusCounts: [],
+  shapefileExemptions: [],
+  kmlExemptions: [],
+  manualCoordinatesExemptions: [],
+  coordinateSystemVolume: [],
+  byArticle: [],
+  byMarinePlanArea: [],
+  byCoastalOperationsArea: []
+}
+
 export const buildExemptionSummaryPipeline = () => [
   {
     $match: {

--- a/src/exemptions/api/helpers/exemption-summary.js
+++ b/src/exemptions/api/helpers/exemption-summary.js
@@ -8,6 +8,20 @@ const SUMMARY_STATUSES = [
   EXEMPTION_STATUS.WITHDRAWN
 ]
 
+const REPORTING_STATUSES = [
+  EXEMPTION_STATUS.ACTIVE,
+  EXEMPTION_STATUS.SUBMITTED,
+  EXEMPTION_STATUS.WITHDRAWN
+]
+
+const excludeDraftExemptionsMatch = {
+  $match: {
+    status: { $in: REPORTING_STATUSES }
+  }
+}
+
+const reportingFacet = (stages) => [excludeDraftExemptionsMatch, ...stages]
+
 export const buildExemptionSummaryPipeline = () => [
   {
     $match: {
@@ -17,7 +31,7 @@ export const buildExemptionSummaryPipeline = () => [
   {
     $facet: {
       statusCounts: [{ $group: { _id: '$status', count: { $sum: 1 } } }],
-      shapefileExemptions: [
+      shapefileExemptions: reportingFacet([
         {
           $match: {
             siteDetails: {
@@ -29,8 +43,8 @@ export const buildExemptionSummaryPipeline = () => [
           }
         },
         { $count: 'count' }
-      ],
-      kmlExemptions: [
+      ]),
+      kmlExemptions: reportingFacet([
         {
           $match: {
             siteDetails: {
@@ -42,8 +56,8 @@ export const buildExemptionSummaryPipeline = () => [
           }
         },
         { $count: 'count' }
-      ],
-      manualCoordinatesExemptions: [
+      ]),
+      manualCoordinatesExemptions: reportingFacet([
         {
           $match: {
             siteDetails: {
@@ -52,8 +66,8 @@ export const buildExemptionSummaryPipeline = () => [
           }
         },
         { $count: 'count' }
-      ],
-      coordinateSystemVolume: [
+      ]),
+      coordinateSystemVolume: reportingFacet([
         { $unwind: '$siteDetails' },
         {
           $group: {
@@ -67,23 +81,23 @@ export const buildExemptionSummaryPipeline = () => [
             count: { $sum: 1 }
           }
         }
-      ],
-      byArticle: [
+      ]),
+      byArticle: reportingFacet([
         {
           $match: {
             'mcmsContext.articleCode': { $exists: true, $nin: [null, ''] }
           }
         },
         { $group: { _id: '$mcmsContext.articleCode', count: { $sum: 1 } } }
-      ],
-      byMarinePlanArea: [
+      ]),
+      byMarinePlanArea: reportingFacet([
         { $unwind: '$marinePlanAreas' },
         { $group: { _id: '$marinePlanAreas', count: { $sum: 1 } } }
-      ],
-      byCoastalOperationsArea: [
+      ]),
+      byCoastalOperationsArea: reportingFacet([
         { $unwind: '$coastalOperationsAreas' },
         { $group: { _id: '$coastalOperationsAreas', count: { $sum: 1 } } }
-      ]
+      ])
     }
   }
 ]

--- a/src/exemptions/api/helpers/exemption-summary.js
+++ b/src/exemptions/api/helpers/exemption-summary.js
@@ -1,0 +1,153 @@
+import { COORDINATE_SYSTEMS } from '../../../shared/common/constants/coordinates.js'
+import { EXEMPTION_STATUS } from '../../constants/exemption.js'
+
+const SUMMARY_STATUSES = [
+  EXEMPTION_STATUS.ACTIVE,
+  EXEMPTION_STATUS.SUBMITTED,
+  EXEMPTION_STATUS.DRAFT,
+  EXEMPTION_STATUS.WITHDRAWN
+]
+
+export const buildExemptionSummaryPipeline = () => [
+  {
+    $match: {
+      status: { $in: SUMMARY_STATUSES }
+    }
+  },
+  {
+    $facet: {
+      statusCounts: [{ $group: { _id: '$status', count: { $sum: 1 } } }],
+      shapefileExemptions: [
+        {
+          $match: {
+            siteDetails: {
+              $elemMatch: {
+                coordinatesType: 'file',
+                fileUploadType: 'shapefile'
+              }
+            }
+          }
+        },
+        { $count: 'count' }
+      ],
+      kmlExemptions: [
+        {
+          $match: {
+            siteDetails: {
+              $elemMatch: {
+                coordinatesType: 'file',
+                fileUploadType: 'kml'
+              }
+            }
+          }
+        },
+        { $count: 'count' }
+      ],
+      manualCoordinatesExemptions: [
+        {
+          $match: {
+            siteDetails: {
+              $elemMatch: { coordinatesType: 'coordinates' }
+            }
+          }
+        },
+        { $count: 'count' }
+      ],
+      coordinateSystemVolume: [
+        { $unwind: '$siteDetails' },
+        {
+          $group: {
+            _id: {
+              $cond: [
+                { $eq: ['$siteDetails.coordinatesType', 'file'] },
+                COORDINATE_SYSTEMS.WGS84,
+                '$siteDetails.coordinateSystem'
+              ]
+            },
+            count: { $sum: 1 }
+          }
+        }
+      ],
+      byArticle: [
+        {
+          $match: {
+            'mcmsContext.articleCode': { $exists: true, $nin: [null, ''] }
+          }
+        },
+        { $group: { _id: '$mcmsContext.articleCode', count: { $sum: 1 } } }
+      ],
+      byMarinePlanArea: [
+        { $unwind: '$marinePlanAreas' },
+        { $group: { _id: '$marinePlanAreas', count: { $sum: 1 } } }
+      ],
+      byCoastalOperationsArea: [
+        { $unwind: '$coastalOperationsAreas' },
+        { $group: { _id: '$coastalOperationsAreas', count: { $sum: 1 } } }
+      ]
+    }
+  }
+]
+
+const countFromFacet = (facetResult) => facetResult[0]?.count ?? 0
+
+const groupedCountsToRecord = (groupedCounts) =>
+  groupedCounts.reduce((acc, item) => {
+    if (item._id != null) {
+      acc[item._id] = item.count
+    }
+    return acc
+  }, {})
+
+const calculatePercentage = (count, total) =>
+  total > 0 ? Math.round((count / total) * 1000) / 10 : 0
+
+export const buildCoordinateSystemVolume = (groupedCounts) => {
+  const countsBySystem = groupedCountsToRecord(groupedCounts)
+  const wgs84Count = countsBySystem[COORDINATE_SYSTEMS.WGS84] ?? 0
+  const bngCount = countsBySystem[COORDINATE_SYSTEMS.OSGB36] ?? 0
+  const total = wgs84Count + bngCount
+
+  return {
+    wgs84: {
+      count: wgs84Count,
+      percentage: calculatePercentage(wgs84Count, total)
+    },
+    bng: {
+      count: bngCount,
+      percentage: calculatePercentage(bngCount, total)
+    },
+    total
+  }
+}
+
+export const buildExemptionSummaryValue = ({
+  statusCounts,
+  shapefileExemptions,
+  kmlExemptions,
+  manualCoordinatesExemptions,
+  coordinateSystemVolume,
+  byArticle,
+  byMarinePlanArea,
+  byCoastalOperationsArea
+}) => {
+  const countsByStatus = groupedCountsToRecord(statusCounts)
+
+  const submittedExemptions =
+    (countsByStatus[EXEMPTION_STATUS.ACTIVE] ?? 0) +
+    (countsByStatus[EXEMPTION_STATUS.SUBMITTED] ?? 0)
+
+  return {
+    submittedExemptions,
+    unsubmittedExemptions: countsByStatus[EXEMPTION_STATUS.DRAFT] ?? 0,
+    withdrawnExemptions: countsByStatus[EXEMPTION_STATUS.WITHDRAWN] ?? 0,
+    coordinatesInputMethod: {
+      shapefile: countFromFacet(shapefileExemptions),
+      kml: countFromFacet(kmlExemptions),
+      manualCoordinates: countFromFacet(manualCoordinatesExemptions)
+    },
+    coordinateSystemVolume: buildCoordinateSystemVolume(coordinateSystemVolume),
+    byArticle: groupedCountsToRecord(byArticle),
+    byMarinePlanArea: groupedCountsToRecord(byMarinePlanArea),
+    byCoastalOperationsArea: groupedCountsToRecord(byCoastalOperationsArea)
+  }
+}

--- a/src/exemptions/api/helpers/exemption-summary.js
+++ b/src/exemptions/api/helpers/exemption-summary.js
@@ -22,6 +22,57 @@ const excludeDraftExemptionsMatch = {
 
 const reportingFacet = (stages) => [excludeDraftExemptionsMatch, ...stages]
 
+const countExemptionsWithSiteMatch = (siteMatch) =>
+  reportingFacet([
+    { $match: { siteDetails: { $elemMatch: siteMatch } } },
+    { $count: 'count' }
+  ])
+
+const groupByFieldFacet = (field) =>
+  reportingFacet([
+    { $unwind: `$${field}` },
+    { $group: { _id: `$${field}`, count: { $sum: 1 } } }
+  ])
+
+const buildReportingFacets = () => ({
+  shapefileExemptions: countExemptionsWithSiteMatch({
+    coordinatesType: 'file',
+    fileUploadType: 'shapefile'
+  }),
+  kmlExemptions: countExemptionsWithSiteMatch({
+    coordinatesType: 'file',
+    fileUploadType: 'kml'
+  }),
+  manualCoordinatesExemptions: countExemptionsWithSiteMatch({
+    coordinatesType: 'coordinates'
+  }),
+  coordinateSystemVolume: reportingFacet([
+    { $unwind: '$siteDetails' },
+    {
+      $group: {
+        _id: {
+          $cond: [
+            { $eq: ['$siteDetails.coordinatesType', 'file'] },
+            COORDINATE_SYSTEMS.WGS84,
+            '$siteDetails.coordinateSystem'
+          ]
+        },
+        count: { $sum: 1 }
+      }
+    }
+  ]),
+  byArticle: reportingFacet([
+    {
+      $match: {
+        'mcmsContext.articleCode': { $exists: true, $nin: [null, ''] }
+      }
+    },
+    { $group: { _id: '$mcmsContext.articleCode', count: { $sum: 1 } } }
+  ]),
+  byMarinePlanArea: groupByFieldFacet('marinePlanAreas'),
+  byCoastalOperationsArea: groupByFieldFacet('coastalOperationsAreas')
+})
+
 export const buildExemptionSummaryPipeline = () => [
   {
     $match: {
@@ -31,73 +82,7 @@ export const buildExemptionSummaryPipeline = () => [
   {
     $facet: {
       statusCounts: [{ $group: { _id: '$status', count: { $sum: 1 } } }],
-      shapefileExemptions: reportingFacet([
-        {
-          $match: {
-            siteDetails: {
-              $elemMatch: {
-                coordinatesType: 'file',
-                fileUploadType: 'shapefile'
-              }
-            }
-          }
-        },
-        { $count: 'count' }
-      ]),
-      kmlExemptions: reportingFacet([
-        {
-          $match: {
-            siteDetails: {
-              $elemMatch: {
-                coordinatesType: 'file',
-                fileUploadType: 'kml'
-              }
-            }
-          }
-        },
-        { $count: 'count' }
-      ]),
-      manualCoordinatesExemptions: reportingFacet([
-        {
-          $match: {
-            siteDetails: {
-              $elemMatch: { coordinatesType: 'coordinates' }
-            }
-          }
-        },
-        { $count: 'count' }
-      ]),
-      coordinateSystemVolume: reportingFacet([
-        { $unwind: '$siteDetails' },
-        {
-          $group: {
-            _id: {
-              $cond: [
-                { $eq: ['$siteDetails.coordinatesType', 'file'] },
-                COORDINATE_SYSTEMS.WGS84,
-                '$siteDetails.coordinateSystem'
-              ]
-            },
-            count: { $sum: 1 }
-          }
-        }
-      ]),
-      byArticle: reportingFacet([
-        {
-          $match: {
-            'mcmsContext.articleCode': { $exists: true, $nin: [null, ''] }
-          }
-        },
-        { $group: { _id: '$mcmsContext.articleCode', count: { $sum: 1 } } }
-      ]),
-      byMarinePlanArea: reportingFacet([
-        { $unwind: '$marinePlanAreas' },
-        { $group: { _id: '$marinePlanAreas', count: { $sum: 1 } } }
-      ]),
-      byCoastalOperationsArea: reportingFacet([
-        { $unwind: '$coastalOperationsAreas' },
-        { $group: { _id: '$coastalOperationsAreas', count: { $sum: 1 } } }
-      ])
+      ...buildReportingFacets()
     }
   }
 ]

--- a/src/exemptions/api/helpers/exemption-summary.test.js
+++ b/src/exemptions/api/helpers/exemption-summary.test.js
@@ -18,6 +18,17 @@ describe('exemption-summary helper', () => {
         EXEMPTION_STATUS.DRAFT,
         EXEMPTION_STATUS.WITHDRAWN
       ])
+      expect(pipeline[1].$facet.shapefileExemptions[0]).toEqual({
+        $match: {
+          status: {
+            $in: [
+              EXEMPTION_STATUS.ACTIVE,
+              EXEMPTION_STATUS.SUBMITTED,
+              EXEMPTION_STATUS.WITHDRAWN
+            ]
+          }
+        }
+      })
       expect(pipeline[1].$facet).toMatchObject({
         statusCounts: expect.any(Array),
         shapefileExemptions: expect.any(Array),
@@ -101,6 +112,28 @@ describe('exemption-summary helper', () => {
         },
         byCoastalOperationsArea: {
           South: 1
+        }
+      })
+    })
+
+    it('maps reporting metrics independently of draft status counts', () => {
+      expect(
+        buildExemptionSummaryValue({
+          statusCounts: [{ _id: EXEMPTION_STATUS.DRAFT, count: 5 }],
+          shapefileExemptions: [],
+          kmlExemptions: [],
+          manualCoordinatesExemptions: [{ count: 2 }],
+          coordinateSystemVolume: [{ _id: 'wgs84', count: 2 }],
+          byArticle: [],
+          byMarinePlanArea: [],
+          byCoastalOperationsArea: []
+        })
+      ).toMatchObject({
+        unsubmittedExemptions: 5,
+        coordinatesInputMethod: {
+          shapefile: 0,
+          kml: 0,
+          manualCoordinates: 2
         }
       })
     })

--- a/src/exemptions/api/helpers/exemption-summary.test.js
+++ b/src/exemptions/api/helpers/exemption-summary.test.js
@@ -1,0 +1,140 @@
+import { expect } from 'vitest'
+import { EXEMPTION_STATUS } from '../../constants/exemption.js'
+import {
+  buildCoordinateSystemVolume,
+  buildExemptionSummaryPipeline,
+  buildExemptionSummaryValue
+} from './exemption-summary.js'
+
+describe('exemption-summary helper', () => {
+  describe('buildExemptionSummaryPipeline', () => {
+    it('includes status match and facet aggregations', () => {
+      const pipeline = buildExemptionSummaryPipeline()
+
+      expect(pipeline).toHaveLength(2)
+      expect(pipeline[0].$match.status.$in).toEqual([
+        EXEMPTION_STATUS.ACTIVE,
+        EXEMPTION_STATUS.SUBMITTED,
+        EXEMPTION_STATUS.DRAFT,
+        EXEMPTION_STATUS.WITHDRAWN
+      ])
+      expect(pipeline[1].$facet).toMatchObject({
+        statusCounts: expect.any(Array),
+        shapefileExemptions: expect.any(Array),
+        kmlExemptions: expect.any(Array),
+        manualCoordinatesExemptions: expect.any(Array),
+        coordinateSystemVolume: expect.any(Array),
+        byArticle: expect.any(Array),
+        byMarinePlanArea: expect.any(Array),
+        byCoastalOperationsArea: expect.any(Array)
+      })
+    })
+  })
+
+  describe('buildCoordinateSystemVolume', () => {
+    it('calculates WGS84 and BNG counts and percentages', () => {
+      expect(
+        buildCoordinateSystemVolume([
+          { _id: 'wgs84', count: 3 },
+          { _id: 'osgb36', count: 1 }
+        ])
+      ).toEqual({
+        wgs84: { count: 3, percentage: 75 },
+        bng: { count: 1, percentage: 25 },
+        total: 4
+      })
+    })
+
+    it('returns zero percentages when there is no site data', () => {
+      expect(buildCoordinateSystemVolume([])).toEqual({
+        wgs84: { count: 0, percentage: 0 },
+        bng: { count: 0, percentage: 0 },
+        total: 0
+      })
+    })
+  })
+
+  describe('buildExemptionSummaryValue', () => {
+    it('maps facet aggregation results into the summary response', () => {
+      expect(
+        buildExemptionSummaryValue({
+          statusCounts: [
+            { _id: EXEMPTION_STATUS.ACTIVE, count: 4 },
+            { _id: EXEMPTION_STATUS.SUBMITTED, count: 2 },
+            { _id: EXEMPTION_STATUS.DRAFT, count: 3 },
+            { _id: EXEMPTION_STATUS.WITHDRAWN, count: 1 }
+          ],
+          shapefileExemptions: [{ count: 2 }],
+          kmlExemptions: [{ count: 1 }],
+          manualCoordinatesExemptions: [{ count: 5 }],
+          coordinateSystemVolume: [
+            { _id: 'wgs84', count: 6 },
+            { _id: 'osgb36', count: 2 }
+          ],
+          byArticle: [
+            { _id: '25', count: 3 },
+            { _id: '17', count: 2 }
+          ],
+          byMarinePlanArea: [{ _id: 'East inshore', count: 2 }],
+          byCoastalOperationsArea: [{ _id: 'South', count: 1 }]
+        })
+      ).toEqual({
+        submittedExemptions: 6,
+        unsubmittedExemptions: 3,
+        withdrawnExemptions: 1,
+        coordinatesInputMethod: {
+          shapefile: 2,
+          kml: 1,
+          manualCoordinates: 5
+        },
+        coordinateSystemVolume: {
+          wgs84: { count: 6, percentage: 75 },
+          bng: { count: 2, percentage: 25 },
+          total: 8
+        },
+        byArticle: {
+          25: 3,
+          17: 2
+        },
+        byMarinePlanArea: {
+          'East inshore': 2
+        },
+        byCoastalOperationsArea: {
+          South: 1
+        }
+      })
+    })
+
+    it('returns zero counts when facet results are empty', () => {
+      expect(
+        buildExemptionSummaryValue({
+          statusCounts: [],
+          shapefileExemptions: [],
+          kmlExemptions: [],
+          manualCoordinatesExemptions: [],
+          coordinateSystemVolume: [],
+          byArticle: [],
+          byMarinePlanArea: [],
+          byCoastalOperationsArea: []
+        })
+      ).toEqual({
+        submittedExemptions: 0,
+        unsubmittedExemptions: 0,
+        withdrawnExemptions: 0,
+        coordinatesInputMethod: {
+          shapefile: 0,
+          kml: 0,
+          manualCoordinates: 0
+        },
+        coordinateSystemVolume: {
+          wgs84: { count: 0, percentage: 0 },
+          bng: { count: 0, percentage: 0 },
+          total: 0
+        },
+        byArticle: {},
+        byMarinePlanArea: {},
+        byCoastalOperationsArea: {}
+      })
+    })
+  })
+})


### PR DESCRIPTION
Add coordinate input, coordinate system, article, and geo area breakdowns to GET /exemptions/summary.
The endpoint now returns:
- Exemption counts by coordinates input method (shapefile, KML, manual)
- Site-level WGS84 vs BNG volume and percentages
- Exemption counts by MCMS article code
- Exemption counts by Marine Plan Area and Coastal Operations Area
Aggregation logic is extracted into a dedicated helper using a single MongoDB $facet pipeline. Unit and integration tests are updated to cover the new response shape.