### PR TITLE
chore(deps): override shell-quote to ^1.8.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14378,9 +14378,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
     "postcss": "^8.5.12",
     "fast-xml-parser": "^5.5.7",
     "picomatch": "^2.3.2 || ^4.0.4",
-    "brace-expansion": "^5.0.6"
+    "brace-expansion": "^5.0.6",
+    "shell-quote": "^1.8.4"
   }
 }


### PR DESCRIPTION
 Add an npm override pinning shell-quote to ^1.8.4, bumping the resolved
 transitive (dev) dependency from 1.8.3 to 1.8.4.

 Introduced by `npm-run-all` v4.1.5