### PR TITLE
ML-1340: Water Framework Directive upload page

### DIFF
--- a/src/marine-licences/api/controllers/update-water-framework-directive.integration.test.js
+++ b/src/marine-licences/api/controllers/update-water-framework-directive.integration.test.js
@@ -7,6 +7,8 @@ import {
 import { ObjectId } from 'mongodb'
 import { collectionMarineLicences } from '../../../shared/common/constants/db-collections.js'
 
+vi.mock('../helpers/validateWfdUpload.js')
+
 describe('PATCH /marine-licence/water-framework-directive - integration tests', async () => {
   const getServer = await setupTestServer()
   const contactId = '123e4567-e89b-12d3-a456-426614174000'

--- a/src/marine-licences/api/controllers/update-water-framework-directive.integration.test.js
+++ b/src/marine-licences/api/controllers/update-water-framework-directive.integration.test.js
@@ -42,12 +42,9 @@ describe('PATCH /marine-licence/water-framework-directive - integration tests', 
       .collection(collectionMarineLicences)
       .findOne({ _id: marineLicenceId })
 
-    expect(updatedLicence.waterFrameworkDirective).toEqual({
-      assessmentChanged: 'no',
-      excludedActivities: 'no',
-      nauticalMile: 'yes',
-      previousAssessment: 'no'
-    })
+    expect(updatedLicence.waterFrameworkDirective).toEqual(
+      mockWaterFrameworkDirective
+    )
   })
 
   test('successfully updates water framework directive with nauticalMile no', async () => {

--- a/src/marine-licences/api/controllers/update-water-framework-directive.integration.test.js
+++ b/src/marine-licences/api/controllers/update-water-framework-directive.integration.test.js
@@ -82,6 +82,44 @@ describe('PATCH /marine-licence/water-framework-directive - integration tests', 
     })
   })
 
+  test('successfully updates water framework directive with nauticalMile yes and excludedActivities yes', async () => {
+    const marineLicence = createCompleteMarineLicence({
+      _id: marineLicenceId,
+      contactId,
+      waterFrameworkDirective: { nauticalMile: 'no' }
+    })
+    await globalThis.mockMongo
+      .collection(collectionMarineLicences)
+      .insertOne(marineLicence)
+
+    const payload = {
+      id: marineLicenceId.toString(),
+      waterFrameworkDirective: {
+        nauticalMile: 'yes',
+        excludedActivities: 'yes'
+      }
+    }
+
+    const { statusCode, body } = await makePatchRequest({
+      server: getServer(),
+      url: '/marine-licence/water-framework-directive',
+      contactId,
+      payload
+    })
+
+    expect(statusCode).toBe(200)
+    expect(body).toEqual({ message: 'success' })
+
+    const updatedLicence = await globalThis.mockMongo
+      .collection(collectionMarineLicences)
+      .findOne({ _id: marineLicenceId })
+
+    expect(updatedLicence.waterFrameworkDirective).toEqual({
+      nauticalMile: 'yes',
+      excludedActivities: 'yes'
+    })
+  })
+
   test('returns 404 when marine licence does not exist', async () => {
     const nonExistentId = new ObjectId()
 

--- a/src/marine-licences/api/controllers/update-water-framework-directive.js
+++ b/src/marine-licences/api/controllers/update-water-framework-directive.js
@@ -4,6 +4,7 @@ import { StatusCodes } from 'http-status-codes'
 import { ObjectId } from 'mongodb'
 import { collectionMarineLicences } from '../../../shared/common/constants/db-collections.js'
 import { authorizeOwnership } from '../../../shared/helpers/authorize-ownership.js'
+import { validateWfdUpload } from '../helpers/validateWfdUpload.js'
 
 export const updateWaterFrameworkDirectiveController = {
   options: {
@@ -20,7 +21,13 @@ export const updateWaterFrameworkDirectiveController = {
   handler: async (request, h) => {
     try {
       const { payload, db } = request
+
       const { waterFrameworkDirective, id, updatedAt, updatedBy } = payload
+
+      if (waterFrameworkDirective.nauticalMile !== 'no') {
+        await validateWfdUpload(waterFrameworkDirective)
+      }
+
       await db.collection(collectionMarineLicences).updateOne(
         { _id: ObjectId.createFromHexString(id) },
         {

--- a/src/marine-licences/api/controllers/update-water-framework-directive.js
+++ b/src/marine-licences/api/controllers/update-water-framework-directive.js
@@ -6,6 +6,18 @@ import { collectionMarineLicences } from '../../../shared/common/constants/db-co
 import { authorizeOwnership } from '../../../shared/helpers/authorize-ownership.js'
 import { validateWfdUpload } from '../helpers/validateWfdUpload.js'
 
+const hasUpload = (waterFrameworkDirective) => {
+  if (waterFrameworkDirective.nauticalMile !== 'yes') {
+    return false
+  }
+
+  if (waterFrameworkDirective.excludedActivities === 'yes') {
+    return false
+  }
+
+  return true
+}
+
 export const updateWaterFrameworkDirectiveController = {
   options: {
     payload: {
@@ -24,7 +36,7 @@ export const updateWaterFrameworkDirectiveController = {
 
       const { waterFrameworkDirective, id, updatedAt, updatedBy } = payload
 
-      if (waterFrameworkDirective.nauticalMile !== 'no') {
+      if (hasUpload(waterFrameworkDirective)) {
         await validateWfdUpload(waterFrameworkDirective)
       }
 

--- a/src/marine-licences/api/controllers/update-water-framework-directive.test.js
+++ b/src/marine-licences/api/controllers/update-water-framework-directive.test.js
@@ -1,6 +1,9 @@
 import { vi } from 'vitest'
 import { ObjectId } from 'mongodb'
 import { updateWaterFrameworkDirectiveController } from './update-water-framework-directive.js'
+import { validateWfdUpload } from '../helpers/validateWfdUpload.js'
+
+vi.mock('../helpers/validateWfdUpload.js')
 
 describe('PATCH /marine-licence/water-framework-directive', () => {
   const mockAuditPayload = {
@@ -29,5 +32,9 @@ describe('PATCH /marine-licence/water-framework-directive', () => {
         mockHandler
       )
     ).rejects.toThrow(`Error updating water framework directive: ${mockError}`)
+
+    expect(validateWfdUpload).toHaveBeenCalledWith(
+      mockPayload.waterFrameworkDirective
+    )
   })
 })

--- a/src/marine-licences/api/controllers/update-water-framework-directive.test.js
+++ b/src/marine-licences/api/controllers/update-water-framework-directive.test.js
@@ -37,4 +37,27 @@ describe('PATCH /marine-licence/water-framework-directive', () => {
       mockPayload.waterFrameworkDirective
     )
   })
+
+  it('should not call validateWfdUpload when excludedActivities is yes', async () => {
+    const { mockMongo, mockHandler } = global
+    const mockPayload = {
+      id: new ObjectId().toHexString(),
+      waterFrameworkDirective: {
+        nauticalMile: 'yes',
+        excludedActivities: 'yes'
+      },
+      ...mockAuditPayload
+    }
+
+    vi.spyOn(mockMongo, 'collection').mockImplementation(() => ({
+      updateOne: vi.fn().mockResolvedValueOnce({})
+    }))
+
+    await updateWaterFrameworkDirectiveController.handler(
+      { db: mockMongo, payload: mockPayload },
+      mockHandler
+    )
+
+    expect(validateWfdUpload).not.toHaveBeenCalled()
+  })
 })

--- a/src/marine-licences/api/helpers/createTaskList.js
+++ b/src/marine-licences/api/helpers/createTaskList.js
@@ -154,14 +154,22 @@ const getSiteDetailsStatus = (siteDetails) => {
 
 const checkWaterFrameworkDirective = (wfd) => {
   const requiredValues = [
-    'assessmentChanged',
+    'nauticalMile',
     'previousAssessment',
     'excludedActivities',
     'uploadedFile',
     's3Location'
   ]
 
-  const siteStatus = getStatusFromRequiredFields(wfd, requiredValues)
+  if (wfd.previousAssessment === 'yes') {
+    requiredValues.push('assessmentChanged')
+  }
+
+  const parsedWfd = Object.fromEntries(
+    Object.entries(wfd).filter(([_, value]) => value != null)
+  )
+
+  const siteStatus = getStatusFromRequiredFields(parsedWfd, requiredValues)
 
   if ([siteStatus].every((s) => s === COMPLETED)) {
     return COMPLETED

--- a/src/marine-licences/api/helpers/createTaskList.js
+++ b/src/marine-licences/api/helpers/createTaskList.js
@@ -187,6 +187,10 @@ const getWaterFrameworkDirectiveStatus = (wfd) => {
     return COMPLETED
   }
 
+  if (wfd.excludedActivities === 'yes') {
+    return COMPLETED
+  }
+
   return checkWaterFrameworkDirective(wfd)
 }
 

--- a/src/marine-licences/api/helpers/createTaskList.js
+++ b/src/marine-licences/api/helpers/createTaskList.js
@@ -152,12 +152,34 @@ const getSiteDetailsStatus = (siteDetails) => {
   return hasInProgress ? IN_PROGRESS : COMPLETED
 }
 
-const getWaterFrameworkDirectiveStatus = (wfd) => {
-  if (wfd?.nauticalMile === 'no') {
+const checkWaterFrameworkDirective = (wfd) => {
+  const requiredValues = [
+    'assessmentChanged',
+    'previousAssessment',
+    'excludedActivities',
+    'uploadedFile',
+    's3Location'
+  ]
+
+  const siteStatus = getStatusFromRequiredFields(wfd, requiredValues)
+
+  if ([siteStatus].every((s) => s === COMPLETED)) {
     return COMPLETED
   }
 
   return INCOMPLETE
+}
+
+const getWaterFrameworkDirectiveStatus = (wfd) => {
+  if (!wfd) {
+    return INCOMPLETE
+  }
+
+  if (wfd.nauticalMile === 'no') {
+    return COMPLETED
+  }
+
+  return checkWaterFrameworkDirective(wfd)
 }
 
 export const createTaskList = (marineLicence, isCitizen = false) => {

--- a/src/marine-licences/api/helpers/createTaskList.test.js
+++ b/src/marine-licences/api/helpers/createTaskList.test.js
@@ -266,6 +266,20 @@ describe('createTaskList', () => {
     )
   })
 
+  it('should set waterFrameworkDirective to COMPLETED when nauticalMile is yes and excludedActivities is yes', () => {
+    const marineLicence = {
+      siteDetails: [{ ...mockFileUploadSite, activityDetails: null }],
+      waterFrameworkDirective: {
+        nauticalMile: 'yes',
+        excludedActivities: 'yes'
+      }
+    }
+
+    expect(createTaskList(marineLicence).waterFrameworkDirective).toBe(
+      COMPLETED
+    )
+  })
+
   it('should set waterFrameworkDirective to INCOMPLETE when previousAssessment is yes and assessmentChanged is missing', () => {
     const marineLicence = {
       siteDetails: [{ ...mockFileUploadSite, activityDetails: null }],

--- a/src/marine-licences/api/helpers/createTaskList.test.js
+++ b/src/marine-licences/api/helpers/createTaskList.test.js
@@ -7,7 +7,8 @@ import {
 import {
   mockFileUploadSite,
   mockCircleSite,
-  mockMultipleSite
+  mockMultipleSite,
+  mockWaterFrameworkDirective
 } from '../../../../tests/test.fixture.js'
 import { createActivityDetails } from './create-empty-activity-details.js'
 
@@ -225,6 +226,44 @@ describe('createTaskList', () => {
     }
 
     expect(createTaskList(marineLicence).siteDetails).toBe(IN_PROGRESS)
+  })
+
+  it('should correctly set waterFrameworkDirective to INCOMPLETE when fields are missing', () => {
+    const marineLicence = {
+      projectName: 'Test Project',
+      specialLegalPowers: 'Some powers',
+      otherAuthorities: 'Some authorities',
+      siteDetails: [
+        {
+          ...mockFileUploadSite,
+          activityDetails: null
+        }
+      ],
+      waterFrameworkDirective: { nauticalMile: 'yes' }
+    }
+
+    expect(createTaskList(marineLicence).waterFrameworkDirective).toBe(
+      INCOMPLETE
+    )
+  })
+
+  it('should correctly set waterFrameworkDirective to COMPLETE when fields are not missing', () => {
+    const marineLicence = {
+      projectName: 'Test Project',
+      specialLegalPowers: 'Some powers',
+      otherAuthorities: 'Some authorities',
+      siteDetails: [
+        {
+          ...mockFileUploadSite,
+          activityDetails: null
+        }
+      ],
+      waterFrameworkDirective: mockWaterFrameworkDirective
+    }
+
+    expect(createTaskList(marineLicence).waterFrameworkDirective).toBe(
+      COMPLETED
+    )
   })
 
   describe('circle site (coordinatesType=coordinates, coordinatesEntry=single)', () => {

--- a/src/marine-licences/api/helpers/createTaskList.test.js
+++ b/src/marine-licences/api/helpers/createTaskList.test.js
@@ -266,6 +266,21 @@ describe('createTaskList', () => {
     )
   })
 
+  it('should set waterFrameworkDirective to INCOMPLETE when previousAssessment is yes and assessmentChanged is missing', () => {
+    const marineLicence = {
+      siteDetails: [{ ...mockFileUploadSite, activityDetails: null }],
+      waterFrameworkDirective: {
+        ...mockWaterFrameworkDirective,
+        previousAssessment: 'yes',
+        assessmentChanged: undefined
+      }
+    }
+
+    expect(createTaskList(marineLicence).waterFrameworkDirective).toBe(
+      INCOMPLETE
+    )
+  })
+
   describe('circle site (coordinatesType=coordinates, coordinatesEntry=single)', () => {
     it('should return siteDetails as COMPLETED when all circle fields and activity details are present', () => {
       const marineLicence = {

--- a/src/marine-licences/api/helpers/validateWfdUpload.js
+++ b/src/marine-licences/api/helpers/validateWfdUpload.js
@@ -6,29 +6,26 @@ import { createLogger } from '../../../shared/common/helpers/logging/logger.js'
 const logger = createLogger()
 const logSystem = 'WaterFrameworkDirective:Update Controller'
 
-const ALLOWED_CONTENT_TYPES = [
+const ALLOWED_CONTENT_TYPES = new Set([
   'application/vnd.oasis.opendocument.text',
   'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
-]
+])
 
 export const validateWfdUpload = async (waterFrameworkDirective) => {
-  const { s3Location } = waterFrameworkDirective
+  const { s3Bucket, s3Key } = waterFrameworkDirective.s3Location
 
   // Validate S3 bucket against config
   const allowedBucket = config.get('cdp.uploadBucket')
-  if (s3Location.s3Bucket !== allowedBucket) {
+  if (s3Bucket !== allowedBucket) {
     logger.warn(`${logSystem}: S3 bucket validation failed`)
 
     throw Boom.forbidden('Invalid S3 bucket')
   }
 
-  // Validate file size
-  const { s3Bucket, s3Key } = s3Location
-
   const metadata = await blobService.validateFileSize(s3Bucket, s3Key)
 
   // Validate file type
-  if (!ALLOWED_CONTENT_TYPES.includes(metadata.contentType)) {
+  if (!ALLOWED_CONTENT_TYPES.has(metadata.contentType)) {
     logger.warn(`${logSystem}: File type validation failed`)
 
     throw Boom.unsupportedMediaType('File must be an ODT or DOCX document')

--- a/src/marine-licences/api/helpers/validateWfdUpload.js
+++ b/src/marine-licences/api/helpers/validateWfdUpload.js
@@ -1,0 +1,40 @@
+import { config } from '../../../config.js'
+import Boom from '@hapi/boom'
+import { blobService } from '../../../shared/services/data-service/blob-service.js'
+import { createLogger } from '../../../shared/common/helpers/logging/logger.js'
+
+const logger = createLogger()
+const logSystem = 'WaterFrameworkDirective:Update Controller'
+
+const ALLOWED_CONTENT_TYPES = [
+  'application/vnd.oasis.opendocument.text',
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
+]
+
+export const validateWfdUpload = async (waterFrameworkDirective) => {
+  const { s3Location } = waterFrameworkDirective
+
+  // Validate S3 bucket against config
+  const allowedBucket = config.get('cdp.uploadBucket')
+  if (s3Location.s3Bucket !== allowedBucket) {
+    logger.warn(`${logSystem}: S3 bucket validation failed`)
+
+    throw Boom.forbidden('Invalid S3 bucket')
+  }
+
+  // Validate file size
+  const { s3Bucket, s3Key } = s3Location
+
+  const metadata = await blobService.validateFileSize(s3Bucket, s3Key)
+
+  // Validate file type
+  if (!ALLOWED_CONTENT_TYPES.includes(metadata.contentType)) {
+    logger.warn(`${logSystem}: File type validation failed`)
+
+    throw Boom.unsupportedMediaType('File must be an ODT or DOCX document')
+  }
+
+  logger.info(
+    `${this.logSystem}: Successfully validated Water Framework Directive file upload`
+  )
+}

--- a/src/marine-licences/api/helpers/validateWfdUpload.js
+++ b/src/marine-licences/api/helpers/validateWfdUpload.js
@@ -35,6 +35,6 @@ export const validateWfdUpload = async (waterFrameworkDirective) => {
   }
 
   logger.info(
-    `${this.logSystem}: Successfully validated Water Framework Directive file upload`
+    `${logSystem}: Successfully validated Water Framework Directive file upload`
   )
 }

--- a/src/marine-licences/api/helpers/validateWfdUpload.js
+++ b/src/marine-licences/api/helpers/validateWfdUpload.js
@@ -4,7 +4,7 @@ import { blobService } from '../../../shared/services/data-service/blob-service.
 import { createLogger } from '../../../shared/common/helpers/logging/logger.js'
 
 const logger = createLogger()
-const logSystem = 'WaterFrameworkDirective:Update Controller'
+const logSystem = 'WaterFrameworkDirective:Upload Validation'
 
 const ALLOWED_CONTENT_TYPES = new Set([
   'application/vnd.oasis.opendocument.text',

--- a/src/marine-licences/api/helpers/validateWfdUpload.test.js
+++ b/src/marine-licences/api/helpers/validateWfdUpload.test.js
@@ -1,0 +1,85 @@
+import { mockWaterFrameworkDirective } from '../../../../tests/test.fixture.js'
+import { validateWfdUpload } from './validateWfdUpload.js'
+import Boom from '@hapi/boom'
+import { config } from '../../../config.js'
+import { blobService } from '../../../shared/services/data-service/blob-service.js'
+
+vi.mock('../../../config.js', () => ({
+  config: {
+    get: vi.fn()
+  }
+}))
+
+vi.mock('../../../shared/services/data-service/blob-service.js', () => ({
+  blobService: {
+    validateFileSize: vi.fn()
+  }
+}))
+
+const mockLogger = vi.hoisted(() => ({
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn()
+}))
+
+vi.mock('../../../shared/common/helpers/logging/logger.js', () => ({
+  createLogger: vi.fn().mockReturnValue(mockLogger)
+}))
+
+describe('validateWfdUpload', () => {
+  beforeEach(() => {
+    config.get.mockReturnValue('mmo-uploads')
+    blobService.validateFileSize.mockResolvedValue({
+      contentType:
+        'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
+    })
+  })
+
+  test('should throw forbidden error when s3Bucket does not match config', async () => {
+    const invalidWfd = {
+      ...mockWaterFrameworkDirective,
+      s3Location: { s3Bucket: 'wrong-bucket' }
+    }
+
+    await expect(validateWfdUpload(invalidWfd)).rejects.toThrow(
+      Boom.forbidden('Invalid S3 bucket')
+    )
+  })
+
+  test('should validate against configured bucket name', async () => {
+    config.get.mockReturnValue('different-bucket')
+
+    const mockWaterFrameworkDirectiveValid = {
+      ...mockWaterFrameworkDirective,
+      s3Location: {
+        ...mockWaterFrameworkDirective.s3Location,
+        s3Bucket: 'different-bucket'
+      }
+    }
+
+    await expect(
+      validateWfdUpload(mockWaterFrameworkDirectiveValid)
+    ).resolves.toBeUndefined()
+  })
+
+  test('should throw unsupported media type error when file is not odt or docx', async () => {
+    blobService.validateFileSize.mockResolvedValue({
+      contentType: 'application/zip'
+    })
+
+    await expect(
+      validateWfdUpload(mockWaterFrameworkDirective)
+    ).rejects.toThrow(
+      Boom.unsupportedMediaType('File must be an ODT or DOCX document')
+    )
+  })
+
+  test('should pass validation for an odt file', async () => {
+    blobService.validateFileSize.mockResolvedValue({
+      contentType: 'application/vnd.oasis.opendocument.text'
+    })
+
+    await validateWfdUpload(mockWaterFrameworkDirective)
+  })
+})

--- a/src/marine-licences/models/water-framework-directive/file-upload.js
+++ b/src/marine-licences/models/water-framework-directive/file-upload.js
@@ -1,0 +1,52 @@
+import joi from 'joi'
+
+export const uploadedFileFieldSchema = joi
+  .object({
+    filename: joi.string().required().messages({
+      'any.required': 'UPLOADED_FILE_FILENAME_REQUIRED',
+      'string.empty': 'UPLOADED_FILE_FILENAME_REQUIRED'
+    })
+  })
+  .required()
+  .messages({
+    'any.required': 'UPLOADED_FILE_REQUIRED',
+    'object.base': 'UPLOADED_FILE_INVALID'
+  })
+
+export const s3LocationFieldSchema = joi
+  .object({
+    s3Bucket: joi.string().required().messages({
+      'any.required': 'S3_BUCKET_REQUIRED',
+      'string.empty': 'S3_BUCKET_REQUIRED'
+    }),
+    s3Key: joi.string().required().messages({
+      'any.required': 'S3_KEY_REQUIRED',
+      'string.empty': 'S3_KEY_REQUIRED'
+    }),
+    checksumSha256: joi.string().required().messages({
+      'any.required': 'CHECKSUM_REQUIRED',
+      'string.empty': 'CHECKSUM_REQUIRED'
+    })
+  })
+  .required()
+  .messages({
+    'any.required': 'S3_LOCATION_REQUIRED',
+    'object.base': 'S3_LOCATION_INVALID'
+  })
+
+export const fileUploadValidationSchema = {
+  uploadedFile: joi.when('nauticalMile', {
+    is: 'yes',
+    then: uploadedFileFieldSchema,
+    otherwise: joi.forbidden().messages({
+      'any.unknown': 'WATER_FRAMEWORK_DIRECTIVE_INVALID'
+    })
+  }),
+  s3Location: joi.when('nauticalMile', {
+    is: 'yes',
+    then: s3LocationFieldSchema,
+    otherwise: joi.forbidden().messages({
+      'any.unknown': 'WATER_FRAMEWORK_DIRECTIVE_INVALID'
+    })
+  })
+}

--- a/src/marine-licences/models/water-framework-directive/file-upload.js
+++ b/src/marine-licences/models/water-framework-directive/file-upload.js
@@ -1,38 +1,8 @@
 import joi from 'joi'
-
-export const uploadedFileFieldSchema = joi
-  .object({
-    filename: joi.string().required().messages({
-      'any.required': 'UPLOADED_FILE_FILENAME_REQUIRED',
-      'string.empty': 'UPLOADED_FILE_FILENAME_REQUIRED'
-    })
-  })
-  .required()
-  .messages({
-    'any.required': 'UPLOADED_FILE_REQUIRED',
-    'object.base': 'UPLOADED_FILE_INVALID'
-  })
-
-export const s3LocationFieldSchema = joi
-  .object({
-    s3Bucket: joi.string().required().messages({
-      'any.required': 'S3_BUCKET_REQUIRED',
-      'string.empty': 'S3_BUCKET_REQUIRED'
-    }),
-    s3Key: joi.string().required().messages({
-      'any.required': 'S3_KEY_REQUIRED',
-      'string.empty': 'S3_KEY_REQUIRED'
-    }),
-    checksumSha256: joi.string().required().messages({
-      'any.required': 'CHECKSUM_REQUIRED',
-      'string.empty': 'CHECKSUM_REQUIRED'
-    })
-  })
-  .required()
-  .messages({
-    'any.required': 'S3_LOCATION_REQUIRED',
-    'object.base': 'S3_LOCATION_INVALID'
-  })
+import {
+  s3LocationFieldSchema,
+  uploadedFileFieldSchema
+} from '../../../shared/models/site-details/file-upload'
 
 export const fileUploadValidationSchema = {
   uploadedFile: joi.when('nauticalMile', {

--- a/src/marine-licences/models/water-framework-directive/file-upload.js
+++ b/src/marine-licences/models/water-framework-directive/file-upload.js
@@ -2,7 +2,7 @@ import joi from 'joi'
 import {
   s3LocationFieldSchema,
   uploadedFileFieldSchema
-} from '../../../shared/models/site-details/file-upload'
+} from '../../../shared/models/site-details/file-upload.js'
 
 export const fileUploadValidationSchema = {
   uploadedFile: joi.when('nauticalMile', {

--- a/src/marine-licences/models/water-framework-directive/file-upload.js
+++ b/src/marine-licences/models/water-framework-directive/file-upload.js
@@ -7,14 +7,26 @@ import {
 export const fileUploadValidationSchema = {
   uploadedFile: joi.when('nauticalMile', {
     is: 'yes',
-    then: uploadedFileFieldSchema,
+    then: joi.when('excludedActivities', {
+      is: 'yes',
+      then: joi.forbidden().messages({
+        'any.unknown': 'WATER_FRAMEWORK_DIRECTIVE_INVALID'
+      }),
+      otherwise: uploadedFileFieldSchema
+    }),
     otherwise: joi.forbidden().messages({
       'any.unknown': 'WATER_FRAMEWORK_DIRECTIVE_INVALID'
     })
   }),
   s3Location: joi.when('nauticalMile', {
     is: 'yes',
-    then: s3LocationFieldSchema,
+    then: joi.when('excludedActivities', {
+      is: 'yes',
+      then: joi.forbidden().messages({
+        'any.unknown': 'WATER_FRAMEWORK_DIRECTIVE_INVALID'
+      }),
+      otherwise: s3LocationFieldSchema
+    }),
     otherwise: joi.forbidden().messages({
       'any.unknown': 'WATER_FRAMEWORK_DIRECTIVE_INVALID'
     })

--- a/src/marine-licences/models/water-framework-directive/water-framework-directive.js
+++ b/src/marine-licences/models/water-framework-directive/water-framework-directive.js
@@ -5,15 +5,21 @@ import { fileUploadValidationSchema } from './file-upload.js'
 const waterFrameworkDirectiveDetails = {
   assessmentChanged: joi.when('nauticalMile', {
     is: 'yes',
-    then: joi.when('previousAssessment', {
-      is: 'no',
-      then: joi.string().valid('yes', 'no').allow(null).messages({
-        'any.only': 'ASSESSMENT_CHANGED_REQUIRED'
+    then: joi.when('excludedActivities', {
+      is: 'yes',
+      then: joi.forbidden().messages({
+        'any.unknown': 'WATER_FRAMEWORK_DIRECTIVE_INVALID'
       }),
-      otherwise: joi.string().valid('yes', 'no').required().messages({
-        'string.empty': 'ASSESSMENT_CHANGED_REQUIRED',
-        'any.only': 'ASSESSMENT_CHANGED_REQUIRED',
-        'any.required': 'ASSESSMENT_CHANGED_REQUIRED'
+      otherwise: joi.when('previousAssessment', {
+        is: 'no',
+        then: joi.string().valid('yes', 'no').allow(null).messages({
+          'any.only': 'ASSESSMENT_CHANGED_REQUIRED'
+        }),
+        otherwise: joi.string().valid('yes', 'no').required().messages({
+          'string.empty': 'ASSESSMENT_CHANGED_REQUIRED',
+          'any.only': 'ASSESSMENT_CHANGED_REQUIRED',
+          'any.required': 'ASSESSMENT_CHANGED_REQUIRED'
+        })
       })
     }),
     otherwise: joi.forbidden().messages({
@@ -33,10 +39,16 @@ const waterFrameworkDirectiveDetails = {
   }),
   previousAssessment: joi.when('nauticalMile', {
     is: 'yes',
-    then: joi.string().valid('yes', 'no').required().messages({
-      'string.empty': 'PREVIOUS_ASSESSMENT_REQUIRED',
-      'any.only': 'PREVIOUS_ASSESSMENT_REQUIRED',
-      'any.required': 'PREVIOUS_ASSESSMENT_REQUIRED'
+    then: joi.when('excludedActivities', {
+      is: 'yes',
+      then: joi.forbidden().messages({
+        'any.unknown': 'WATER_FRAMEWORK_DIRECTIVE_INVALID'
+      }),
+      otherwise: joi.string().valid('yes', 'no').required().messages({
+        'string.empty': 'PREVIOUS_ASSESSMENT_REQUIRED',
+        'any.only': 'PREVIOUS_ASSESSMENT_REQUIRED',
+        'any.required': 'PREVIOUS_ASSESSMENT_REQUIRED'
+      })
     }),
     otherwise: joi.forbidden().messages({
       'any.unknown': 'WATER_FRAMEWORK_DIRECTIVE_INVALID'

--- a/src/marine-licences/models/water-framework-directive/water-framework-directive.js
+++ b/src/marine-licences/models/water-framework-directive/water-framework-directive.js
@@ -5,10 +5,16 @@ import { fileUploadValidationSchema } from './file-upload.js'
 const waterFrameworkDirectiveDetails = {
   assessmentChanged: joi.when('nauticalMile', {
     is: 'yes',
-    then: joi.string().valid('yes', 'no').required().messages({
-      'string.empty': 'ASSESSMENT_CHANGED_REQUIRED',
-      'any.only': 'ASSESSMENT_CHANGED_REQUIRED',
-      'any.required': 'ASSESSMENT_CHANGED_REQUIRED'
+    then: joi.when('previousAssessment', {
+      is: 'no',
+      then: joi.string().valid('yes', 'no').allow(null).messages({
+        'any.only': 'ASSESSMENT_CHANGED_REQUIRED'
+      }),
+      otherwise: joi.string().valid('yes', 'no').required().messages({
+        'string.empty': 'ASSESSMENT_CHANGED_REQUIRED',
+        'any.only': 'ASSESSMENT_CHANGED_REQUIRED',
+        'any.required': 'ASSESSMENT_CHANGED_REQUIRED'
+      })
     }),
     otherwise: joi.forbidden().messages({
       'any.unknown': 'WATER_FRAMEWORK_DIRECTIVE_INVALID'

--- a/src/marine-licences/models/water-framework-directive/water-framework-directive.js
+++ b/src/marine-licences/models/water-framework-directive/water-framework-directive.js
@@ -1,5 +1,6 @@
 import joi from 'joi'
 import { marineLicenceId } from '../shared-models.js'
+import { fileUploadValidationSchema } from './file-upload.js'
 
 const waterFrameworkDirectiveDetails = {
   assessmentChanged: joi.when('nauticalMile', {
@@ -34,7 +35,8 @@ const waterFrameworkDirectiveDetails = {
     otherwise: joi.forbidden().messages({
       'any.unknown': 'WATER_FRAMEWORK_DIRECTIVE_INVALID'
     })
-  })
+  }),
+  ...fileUploadValidationSchema
 }
 
 export const waterFrameworkDirectiveSchema = joi

--- a/src/marine-licences/models/water-framework-directive/water-framework-directive.test.js
+++ b/src/marine-licences/models/water-framework-directive/water-framework-directive.test.js
@@ -175,6 +175,52 @@ describe('waterFrameworkDirective', () => {
       })
       expect(error.message).toContain('ASSESSMENT_CHANGED_REQUIRED')
     })
+
+    test('should fail if empty for file upload or s3 data', () => {
+      const { error: fileError } = waterFrameworkDirectiveSchema.validate({
+        id: validId,
+        waterFrameworkDirective: {
+          ...mockWaterFrameworkDirective,
+          nauticalMile: 'yes',
+          uploadedFile: ''
+        }
+      })
+      expect(fileError.message).toContain('UPLOADED_FILE_INVALID')
+
+      const { error: s3Error } = waterFrameworkDirectiveSchema.validate({
+        id: validId,
+        waterFrameworkDirective: {
+          ...mockWaterFrameworkDirective,
+          nauticalMile: 'yes',
+          s3Location: ''
+        }
+      })
+      expect(s3Error.message).toContain('S3_LOCATION_INVALID')
+    })
+
+    test('should fail if invalid value for file upload', () => {
+      const { error } = waterFrameworkDirectiveSchema.validate({
+        id: validId,
+        waterFrameworkDirective: {
+          ...mockWaterFrameworkDirective,
+          nauticalMile: 'yes',
+          uploadedFile: { invalidValue: 'test' }
+        }
+      })
+      expect(error.message).toContain('UPLOADED_FILE_FILENAME_REQUIRED')
+    })
+
+    test('should fail if invalid value for s3', () => {
+      const { error } = waterFrameworkDirectiveSchema.validate({
+        id: validId,
+        waterFrameworkDirective: {
+          ...mockWaterFrameworkDirective,
+          nauticalMile: 'yes',
+          s3Location: { invalidValue: 'test' }
+        }
+      })
+      expect(error.message).toContain('S3_BUCKET_REQUIRED')
+    })
   })
 
   describe('nauticalMile no', () => {

--- a/src/marine-licences/models/water-framework-directive/water-framework-directive.test.js
+++ b/src/marine-licences/models/water-framework-directive/water-framework-directive.test.js
@@ -110,7 +110,7 @@ describe('waterFrameworkDirective', () => {
         waterFrameworkDirective: {
           nauticalMile: 'yes',
           assessmentChanged: 'yes',
-          excludedActivities: 'yes'
+          excludedActivities: 'no'
         }
       })
       expect(error.message).toContain('PREVIOUS_ASSESSMENT_REQUIRED')
@@ -122,7 +122,7 @@ describe('waterFrameworkDirective', () => {
         waterFrameworkDirective: {
           nauticalMile: 'yes',
           assessmentChanged: 'yes',
-          excludedActivities: 'yes',
+          excludedActivities: 'no',
           previousAssessment: 'maybe'
         }
       })
@@ -145,7 +145,7 @@ describe('waterFrameworkDirective', () => {
         id: validId,
         waterFrameworkDirective: {
           nauticalMile: 'yes',
-          excludedActivities: 'yes',
+          excludedActivities: 'no',
           previousAssessment: 'yes'
         }
       })
@@ -246,6 +246,31 @@ describe('waterFrameworkDirective', () => {
         }
       })
       expect(error.message).toContain('S3_BUCKET_REQUIRED')
+    })
+  })
+
+  describe('nauticalMile yes and excludedActivities yes', () => {
+    test('should pass with only nauticalMile yes and excludedActivities yes', () => {
+      const { error } = waterFrameworkDirectiveSchema.validate({
+        id: validId,
+        waterFrameworkDirective: {
+          nauticalMile: 'yes',
+          excludedActivities: 'yes'
+        }
+      })
+      expect(error).toBeUndefined()
+    })
+
+    test('should fail if another value is provided', () => {
+      const { error } = waterFrameworkDirectiveSchema.validate({
+        id: validId,
+        waterFrameworkDirective: {
+          nauticalMile: 'yes',
+          excludedActivities: 'yes',
+          previousAssessment: 'yes'
+        }
+      })
+      expect(error.message).toContain('WATER_FRAMEWORK_DIRECTIVE_INVALID')
     })
   })
 

--- a/src/marine-licences/models/water-framework-directive/water-framework-directive.test.js
+++ b/src/marine-licences/models/water-framework-directive/water-framework-directive.test.js
@@ -176,6 +176,32 @@ describe('waterFrameworkDirective', () => {
       expect(error.message).toContain('ASSESSMENT_CHANGED_REQUIRED')
     })
 
+    test('should pass if assessmentChanged is null when previousAssessment is no', () => {
+      const { error } = waterFrameworkDirectiveSchema.validate({
+        id: validId,
+        waterFrameworkDirective: {
+          ...mockWaterFrameworkDirective,
+          nauticalMile: 'yes',
+          previousAssessment: 'no',
+          assessmentChanged: null
+        }
+      })
+      expect(error).toBeUndefined()
+    })
+
+    test('should fail if assessmentChanged is null when previousAssessment is yes', () => {
+      const { error } = waterFrameworkDirectiveSchema.validate({
+        id: validId,
+        waterFrameworkDirective: {
+          ...mockWaterFrameworkDirective,
+          nauticalMile: 'yes',
+          previousAssessment: 'yes',
+          assessmentChanged: null
+        }
+      })
+      expect(error.message).toContain('ASSESSMENT_CHANGED_REQUIRED')
+    })
+
     test('should fail if empty for file upload or s3 data', () => {
       const { error: fileError } = waterFrameworkDirectiveSchema.validate({
         id: validId,

--- a/tests/test.fixture.js
+++ b/tests/test.fixture.js
@@ -108,7 +108,16 @@ export const mockWaterFrameworkDirective = {
   nauticalMile: 'yes',
   assessmentChanged: 'no',
   excludedActivities: 'no',
-  previousAssessment: 'no'
+  previousAssessment: 'no',
+  uploadedFile: {
+    filename: 'Suffolk MMO shapefiles.zip'
+  },
+  s3Location: {
+    s3Bucket: 'mmo-uploads',
+    s3Key:
+      'exemptions/697ff02d-e5e7-4e42-ba47-c36fc116af47/45265950-72fb-4bb7-ab1c-2fb722ab15ec',
+    checksumSha256: 'V3nR8yISvb6pfVp1g1eUdFo5Cer80JpGlqkGAJb/O8k='
+  }
 }
 
 const completedActivityDetails = [


### PR DESCRIPTION
## Description

Water Framework Directive: Upload a File

 ## Changes

- If WFD 'nauticalMile' is 'yes',  's3Location' and 'uploadedFile' are required
- Add to task list for 'Yes' answer to `nauticalMile`
- Validate bucket name, file size and file type. The front end and uploader will handle most of the validation but this gives some extra protection.
