### PR TITLE
Fix Joi CVE-2026-48038 in hapi-pulse transitive dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10481,14 +10481,14 @@
       }
     },
     "node_modules/hapi-pulse/node_modules/joi": {
-      "version": "17.9.2",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-17.9.2.tgz",
-      "integrity": "sha512-Itk/r+V4Dx0V3c7RLFdRh12IOjySm2/WGPMubBT92cQvRfYZhPM2W0hZlctjj72iES8jsRCwp7S/cRmWBnJ4nw==",
+      "version": "17.13.4",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.4.tgz",
+      "integrity": "sha512-1RuuER6kmt8K8I3nIWvPZKi5RQCb568ZPyY4Pwjlua+yo+63ZTmIwxLZH0heBmiKN4uxjvCiarDrjaeH84xicQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@hapi/hoek": "^9.0.0",
-        "@hapi/topo": "^5.0.0",
-        "@sideway/address": "^4.1.3",
+        "@hapi/hoek": "^9.3.0",
+        "@hapi/topo": "^5.1.0",
+        "@sideway/address": "^4.1.5",
         "@sideway/formula": "^3.0.1",
         "@sideway/pinpoint": "^2.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -107,6 +107,9 @@
     "fast-xml-parser": "^5.5.7",
     "picomatch": "^2.3.2 || ^4.0.4",
     "brace-expansion": "^5.0.6",
-    "shell-quote": "^1.8.4"
+    "shell-quote": "^1.8.4",
+    "hapi-pulse": {
+      "joi": "17.13.4"
+    }
   }
 }


### PR DESCRIPTION
## Summary

- Resolves [CVE-2026-48038](https://github.com/advisories/GHSA-q7cg-457f-vx79) (GHSA-q7cg-457f-vx79): Joi can throw an uncaught `RangeError` on deeply nested input when using recursive `.link()` schemas.
- Adds an npm override so `hapi-pulse` uses `joi@17.13.4` instead of `joi@17.9.2`.
- Direct application dependency on `joi@18.2.1` is unchanged and already includes the fix.
