### PR TITLE
Fix npm audit vulnerabilities in js-yaml and undici

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11408,6 +11408,15 @@
         "node": "20 || >=22"
       }
     },
+    "node_modules/jsdom/node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
     "node_modules/jsesc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
         "proj4": "2.20.4",
         "sanitize-html": "2.17.4",
         "shapefile": "^0.6.6",
-        "undici": "8.3.0",
+        "undici": "8.5.0",
         "uuid": "14.0.0"
       },
       "devDependencies": {
@@ -3707,9 +3707,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3727,9 +3724,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3747,9 +3741,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3767,9 +3758,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3787,9 +3775,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3807,9 +3792,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11355,10 +11337,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -11414,15 +11406,6 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
-      }
-    },
-    "node_modules/jsdom/node_modules/undici": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
-      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.18.1"
       }
     },
     "node_modules/jsesc": {
@@ -15345,9 +15328,9 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-8.3.0.tgz",
-      "integrity": "sha512-TkUDgb6tl7KOGZ+7e8E3d2FYgUQgF6z5YypqjWmixVQSQERFcVrVg0ySADm2LVLRh5ljAaHTCR5Fmz3Q34rB7Q==",
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.5.0.tgz",
+      "integrity": "sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg==",
       "license": "MIT",
       "engines": {
         "node": ">=22.19.0"

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "proj4": "2.20.4",
     "sanitize-html": "2.17.4",
     "shapefile": "^0.6.6",
-    "undici": "8.3.0",
+    "undici": "8.5.0",
     "uuid": "14.0.0"
   },
   "devDependencies": {
@@ -111,6 +111,10 @@
     "hapi-pulse": {
       "joi": "17.13.4"
     },
-    "form-data": "4.0.6"
+    "form-data": "4.0.6",
+    "js-yaml": "4.2.0",
+    "jsdom": {
+      "undici": "8.5.0"
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "form-data": "4.0.6",
     "js-yaml": "4.2.0",
     "jsdom": {
-      "undici": "8.5.0"
+      "undici": "7.28.0"
     }
   }
 }


### PR DESCRIPTION
Resolves npm audit findings for js-yaml (moderate) and undici (high).

- Bumps the direct undici dependency from 8.3.0 to 8.5.0.

- Adds a scoped override so jsdom uses undici@7.28.0 instead of vulnerable 7.25.x. jsdom 29 depends on undici 7.x internal APIs (wrap-handler.js, etc.) that were removed in undici 8.x, so forcing 8.5.0 for jsdom breaks KML/geo-parser extraction at runtime.
- Adds a js-yaml override to 4.2.0 so eslint’s transitive dependency is no longer on vulnerable 4.1.1.