### PR TITLE
ML-1247 - MPP - Query marine plan policies

### DIFF
--- a/src/marine-licences/api/helpers/marine-plan-policies/policy-job.js
+++ b/src/marine-licences/api/helpers/marine-plan-policies/policy-job.js
@@ -57,6 +57,7 @@ export const buildPolicyResetFields = (id, existing, newSiteDetails) => {
   return {
     marinePlanPolicyJob: null,
     marinePlanPolicyJobId: null,
-    marinePlanPolicies: []
+    marinePlanPolicies: [],
+    marinePlanPoliciesCount: 0
   }
 }

--- a/src/marine-licences/api/helpers/marine-plan-policies/policy-job.test.js
+++ b/src/marine-licences/api/helpers/marine-plan-policies/policy-job.test.js
@@ -114,7 +114,8 @@ describe('buildPolicyResetFields', () => {
     expect(buildPolicyResetFields(licenceId, existing, [movedSite])).toEqual({
       marinePlanPolicyJob: null,
       marinePlanPolicyJobId: null,
-      marinePlanPolicies: []
+      marinePlanPolicies: [],
+      marinePlanPoliciesCount: 0
     })
   })
 

--- a/src/marine-licences/api/helpers/marine-plan-policies/worker-processor.js
+++ b/src/marine-licences/api/helpers/marine-plan-policies/worker-processor.js
@@ -59,7 +59,8 @@ const computeAndStorePolicies = async (job, licence, db) => {
   })
 
   const result = await setJobStatus(job, MARINE_PLAN_POLICY_JOB_STATUS.READY, {
-    marinePlanPolicies
+    marinePlanPolicies,
+    marinePlanPoliciesCount: marinePlanPolicies.length
   })
   if (result.matchedCount > 0) {
     logger.info(

--- a/src/marine-licences/api/helpers/marine-plan-policies/worker-processor.test.js
+++ b/src/marine-licences/api/helpers/marine-plan-policies/worker-processor.test.js
@@ -132,6 +132,7 @@ describe('policies-worker-processor', () => {
         {
           $set: {
             marinePlanPolicies: mergedPolicies,
+            marinePlanPoliciesCount: mergedPolicies.length,
             marinePlanPolicyJob: 'ready'
           }
         }


### PR DESCRIPTION
This change adds the field marinePlanPoliciesCount to the marine-licence object. 

The field is set at the same time the marinePlanPolicies are set and it is also reset when the site geometries are edited.

This count will be used in a subsequent ticket to display the count on the task list