### PR TITLE
ML-1351 - MPP - MPP task status and policy count

### DIFF
--- a/src/marine-licences/api/controllers/get-marine-licence.integration.test.js
+++ b/src/marine-licences/api/controllers/get-marine-licence.integration.test.js
@@ -50,6 +50,7 @@ describe('Get marine licence - integration tests', async () => {
       marinePlanPolicyJob: null,
       marinePlanPolicies: [],
       marinePlanPolicyResponses: {},
+      marinePlanPolicyResponseCount: 0,
       taskList: {
         projectName: 'COMPLETED',
         otherAuthorities: 'INCOMPLETE',
@@ -97,6 +98,7 @@ describe('Get marine licence - integration tests', async () => {
       marinePlanPolicyJob: null,
       marinePlanPolicies: [],
       marinePlanPolicyResponses: {},
+      marinePlanPolicyResponseCount: 0,
       taskList: {
         projectName: 'COMPLETED',
         otherAuthorities: 'INCOMPLETE',

--- a/src/marine-licences/api/controllers/get-marine-licence.js
+++ b/src/marine-licences/api/controllers/get-marine-licence.js
@@ -47,6 +47,7 @@ export const getMarineLicenceController = ({ requiresAuth }) => ({
         marinePlanPolicyJob: rest.marinePlanPolicyJob ?? null,
         marinePlanPolicies: rest.marinePlanPolicies ?? [],
         marinePlanPolicyResponses: rest.marinePlanPolicyResponses ?? {},
+        marinePlanPolicyResponseCount: rest.marinePlanPolicyResponseCount ?? 0,
         taskList
       }
 

--- a/src/marine-licences/api/controllers/get-marine-licence.test.js
+++ b/src/marine-licences/api/controllers/get-marine-licence.test.js
@@ -132,6 +132,7 @@ describe('GET /marine-licence', () => {
             marinePlanPolicyJob: null,
             marinePlanPolicies: [],
             marinePlanPolicyResponses: {},
+            marinePlanPolicyResponseCount: 0,
             taskList: {
               preferredDates: 'COMPLETED',
               projectName: 'COMPLETED',

--- a/src/marine-licences/api/controllers/save-marine-plan-policy-response.js
+++ b/src/marine-licences/api/controllers/save-marine-plan-policy-response.js
@@ -24,16 +24,33 @@ export const saveMarinePlanPolicyResponseController = {
       const _id = ObjectId.createFromHexString(id)
       const collection = db.collection(collectionMarineLicences)
 
-      const result = await collection.updateOne(
-        { _id },
+      const result = await collection.updateOne({ _id }, [
         {
           $set: {
-            [`marinePlanPolicyResponses.${policyCode}`]: response,
+            marinePlanPolicyResponses: {
+              $mergeObjects: [
+                '$marinePlanPolicyResponses',
+                { [policyCode]: response }
+              ]
+            },
             updatedAt,
             updatedBy
           }
+        },
+        {
+          $set: {
+            marinePlanPolicyResponseCount: {
+              $size: {
+                $filter: {
+                  input: { $objectToArray: '$marinePlanPolicyResponses' },
+                  as: 'r',
+                  cond: { $ne: ['$$r.v', ''] }
+                }
+              }
+            }
+          }
         }
-      )
+      ])
 
       if (result.matchedCount === 0) {
         throw Boom.notFound('Marine licence not found')

--- a/src/marine-licences/api/controllers/save-marine-plan-policy-response.test.js
+++ b/src/marine-licences/api/controllers/save-marine-plan-policy-response.test.js
@@ -78,12 +78,32 @@ describe('PATCH /marine-licence/marine-plan-policy-response', () => {
       expect(mockUpdateOne).toHaveBeenCalledTimes(1)
       expect(mockUpdateOne).toHaveBeenCalledWith(
         { _id: ObjectId.createFromHexString(mockPayload.id) },
-        {
-          $set: {
-            'marinePlanPolicyResponses.S-FISH-1': mockPayload.response,
-            ...mockAuditPayload
+        [
+          {
+            $set: {
+              marinePlanPolicyResponses: {
+                $mergeObjects: [
+                  '$marinePlanPolicyResponses',
+                  { 'S-FISH-1': mockPayload.response }
+                ]
+              },
+              ...mockAuditPayload
+            }
+          },
+          {
+            $set: {
+              marinePlanPolicyResponseCount: {
+                $size: {
+                  $filter: {
+                    input: { $objectToArray: '$marinePlanPolicyResponses' },
+                    as: 'r',
+                    cond: { $ne: ['$$r.v', ''] }
+                  }
+                }
+              }
+            }
           }
-        }
+        ]
       )
       expect(mockHandler.response).toHaveBeenCalledWith({ message: 'success' })
     })


### PR DESCRIPTION
This PR adds marinePlanPolicyResponseCount which is updated when a response is recorded and is also returned with the rest of the marine licence. 