### PR TITLE
ML-1375: lcml identify marine plan areas and coastal ops area

### DIFF
--- a/src/exemptions/api/controllers/backfill-areas.js
+++ b/src/exemptions/api/controllers/backfill-areas.js
@@ -41,12 +41,14 @@ export const backfillAreasController = {
 
       await updateCoastalOperationsAreas(exemption, db, {
         updatedAt,
-        updatedBy
+        updatedBy,
+        collectionName: collectionExemptions
       })
 
       await updateMarinePlanningAreas(exemption, db, {
         updatedAt,
-        updatedBy
+        updatedBy,
+        collectionName: collectionExemptions
       })
 
       await db

--- a/src/exemptions/api/controllers/backfill-areas.test.js
+++ b/src/exemptions/api/controllers/backfill-areas.test.js
@@ -69,12 +69,20 @@ describe('POST /exemption/backfill-areas', () => {
     expect(updateCoastalOperationsAreas).toHaveBeenCalledWith(
       activeExemption,
       mockDb,
-      { updatedAt: undefined, updatedBy: undefined }
+      {
+        updatedAt: undefined,
+        updatedBy: undefined,
+        collectionName: 'exemptions'
+      }
     )
     expect(updateMarinePlanningAreas).toHaveBeenCalledWith(
       activeExemption,
       mockDb,
-      { updatedAt: undefined, updatedBy: undefined }
+      {
+        updatedAt: undefined,
+        updatedBy: undefined,
+        collectionName: 'exemptions'
+      }
     )
 
     expect(mockDb.collection().updateOne).toHaveBeenCalledWith(

--- a/src/exemptions/api/controllers/submit-exemption.js
+++ b/src/exemptions/api/controllers/submit-exemption.js
@@ -102,22 +102,26 @@ const runPostSubmitBackgroundWork = ({
   // not block the other or the Dynamics/EMP queue inserts — geo areas
   // can be backfilled independently via the backfill-areas endpoint.
   Promise.all([
-    updateCoastalOperationsAreas(exemption, db, { updatedAt, updatedBy }).catch(
-      (err) => {
-        request.logger.error(
-          structureErrorForECS(err),
-          `Failed to update coastal operations areas for ${applicationReference}`
-        )
-      }
-    ),
-    updateMarinePlanningAreas(exemption, db, { updatedAt, updatedBy }).catch(
-      (err) => {
-        request.logger.error(
-          structureErrorForECS(err),
-          `Failed to update marine plan areas for ${applicationReference}`
-        )
-      }
-    )
+    updateCoastalOperationsAreas(exemption, db, {
+      updatedAt,
+      updatedBy,
+      collectionName: collectionExemptions
+    }).catch((err) => {
+      request.logger.error(
+        structureErrorForECS(err),
+        `Failed to update coastal operations areas for ${applicationReference}`
+      )
+    }),
+    updateMarinePlanningAreas(exemption, db, {
+      updatedAt,
+      updatedBy,
+      collectionName: collectionExemptions
+    }).catch((err) => {
+      request.logger.error(
+        structureErrorForECS(err),
+        `Failed to update marine plan areas for ${applicationReference}`
+      )
+    })
   ])
     .then(async () => {
       if (isDynamicsEnabled) {

--- a/src/exemptions/api/controllers/submit-exemption.test.js
+++ b/src/exemptions/api/controllers/submit-exemption.test.js
@@ -227,7 +227,8 @@ describe('POST /exemption/submit', () => {
         mockDb,
         {
           updatedAt: mockAuditPayload.updatedAt,
-          updatedBy: mockAuditPayload.updatedBy
+          updatedBy: mockAuditPayload.updatedBy,
+          collectionName: 'exemptions'
         }
       )
 
@@ -236,7 +237,8 @@ describe('POST /exemption/submit', () => {
         mockDb,
         {
           updatedAt: mockAuditPayload.updatedAt,
-          updatedBy: mockAuditPayload.updatedBy
+          updatedBy: mockAuditPayload.updatedBy,
+          collectionName: 'exemptions'
         }
       )
 

--- a/src/exemptions/api/controllers/submit-exemption.test.js
+++ b/src/exemptions/api/controllers/submit-exemption.test.js
@@ -9,10 +9,7 @@ import { REQUEST_QUEUE_STATUS } from '../../../shared/common/constants/request-q
 import { config } from '../../../config.js'
 import { updateMarinePlanningAreas } from '../../../shared/common/helpers/geo/update-marine-planning-areas.js'
 import { updateCoastalOperationsAreas } from '../../../shared/common/helpers/geo/update-coastal-operations-areas.js'
-
-// Flush all pending microtasks and macrotasks so fire-and-forget background
-// promise chains (geo writes → queue inserts) complete before asserting.
-const flushPromises = () => new Promise((resolve) => setTimeout(resolve, 0))
+import { flushPromises } from '../../../../tests/test-helpers.js'
 
 vi.mock('notifications-node-client', () => ({
   NotifyClient: vi.fn().mockImplementation(function () {

--- a/src/marine-licences/api/controllers/submit-marine-licence.js
+++ b/src/marine-licences/api/controllers/submit-marine-licence.js
@@ -84,10 +84,11 @@ const runPostSubmitBackgroundWork = ({
   updatedAt,
   updatedBy,
   applicationReference,
-  request
+  request,
+  isDynamicsEnabled
 }) => {
   // Each geo operation catches its own errors so a failure in one does
-  // not block the other.
+  // not block the other or the Dynamics queue insert — geo areas can be
   Promise.all([
     updateCoastalOperationsAreas(marineLicence, db, {
       updatedAt,
@@ -110,6 +111,22 @@ const runPostSubmitBackgroundWork = ({
       )
     })
   ])
+    .then(async () => {
+      if (isDynamicsEnabled) {
+        await addToDynamicsQueue({
+          request,
+          applicationReference,
+          action: DYNAMICS_REQUEST_ACTIONS.SUBMIT,
+          type: DYNAMICS_QUEUE_TYPES.MARINE_LICENCE
+        })
+      }
+    })
+    .catch((err) => {
+      request.logger.error(
+        structureErrorForECS(err),
+        `Failed to insert Dynamics queue entry for ${applicationReference}`
+      )
+    })
 }
 
 export const submitMarineLicenceController = {
@@ -164,17 +181,9 @@ export const submitMarineLicenceController = {
         updatedAt,
         updatedBy,
         applicationReference,
-        request
+        request,
+        isDynamicsEnabled
       })
-
-      if (isDynamicsEnabled) {
-        await addToDynamicsQueue({
-          request,
-          applicationReference,
-          action: DYNAMICS_REQUEST_ACTIONS.SUBMIT,
-          type: DYNAMICS_QUEUE_TYPES.MARINE_LICENCE
-        })
-      }
 
       const { organisation } = marineLicence
       // async; don't wait for this to complete

--- a/src/marine-licences/api/controllers/submit-marine-licence.js
+++ b/src/marine-licences/api/controllers/submit-marine-licence.js
@@ -17,6 +17,9 @@ import { addToDynamicsQueue } from '../../../shared/common/helpers/dynamics/dyna
 import { config } from '../../../config.js'
 import { sendEmailConfirmation } from '../../../shared/helpers/send-email-confirmation.js'
 import { getOrganisationDetailsFromAuthToken } from '../../../shared/helpers/get-organisation-from-token.js'
+import { updateCoastalOperationsAreas } from '../../../shared/common/helpers/geo/update-coastal-operations-areas.js'
+import { updateMarinePlanningAreas } from '../../../shared/common/helpers/geo/update-marine-planning-areas.js'
+import { structureErrorForECS } from '../../../shared/common/helpers/logging/logger.js'
 
 const checkForIncompleteTasks = (marineLicence, isCitizen) => {
   const taskList = createTaskList(marineLicence, isCitizen)
@@ -75,6 +78,40 @@ const updateMarineLicenceRecord = async ({
   }
 }
 
+const runPostSubmitBackgroundWork = ({
+  marineLicence,
+  db,
+  updatedAt,
+  updatedBy,
+  applicationReference,
+  request
+}) => {
+  // Each geo operation catches its own errors so a failure in one does
+  // not block the other.
+  Promise.all([
+    updateCoastalOperationsAreas(marineLicence, db, {
+      updatedAt,
+      updatedBy,
+      collectionName: collectionMarineLicences
+    }).catch((err) => {
+      request.logger.error(
+        structureErrorForECS(err),
+        `Failed to update coastal operations areas for ${applicationReference}`
+      )
+    }),
+    updateMarinePlanningAreas(marineLicence, db, {
+      updatedAt,
+      updatedBy,
+      collectionName: collectionMarineLicences
+    }).catch((err) => {
+      request.logger.error(
+        structureErrorForECS(err),
+        `Failed to update marine plan areas for ${applicationReference}`
+      )
+    })
+  ])
+}
+
 export const submitMarineLicenceController = {
   options: {
     payload: {
@@ -115,6 +152,19 @@ export const submitMarineLicenceController = {
         payload,
         applicationReference,
         submittedAt
+      })
+
+      const { updatedAt, updatedBy } = payload
+
+      // Run geo lookups in the background so the user receives
+      // applicationReference and submittedAt immediately.
+      runPostSubmitBackgroundWork({
+        marineLicence,
+        db,
+        updatedAt,
+        updatedBy,
+        applicationReference,
+        request
       })
 
       if (isDynamicsEnabled) {

--- a/src/marine-licences/api/controllers/submit-marine-licence.test.js
+++ b/src/marine-licences/api/controllers/submit-marine-licence.test.js
@@ -727,6 +727,49 @@ describe('POST /marine-licence/submit', () => {
 
       expect(addToDynamicsQueue).not.toHaveBeenCalled()
     })
+
+    it('should log and not throw when inserting the Dynamics queue entry fails', async () => {
+      config.get.mockImplementation((key) => {
+        if (key === 'dynamics') return { isDynamicsEnabled: true }
+        if (key === 'frontEndBaseUrl') {
+          return 'https://marine-licensing.defra.gov.uk'
+        }
+        return {}
+      })
+
+      const mockMarineLicence = {
+        _id: ObjectId.createFromHexString(mockMarineLicenceId),
+        contactId: 'test-contact-id',
+        projectName: 'Test Marine Project'
+      }
+
+      mockMarineLicencesCollection.findOne.mockResolvedValue(mockMarineLicence)
+      mockMarineLicencesCollection.updateOne.mockResolvedValue({
+        matchedCount: 1
+      })
+      vi.mocked(addToDynamicsQueue).mockRejectedValueOnce(
+        new Error('Dynamics queue insert failed')
+      )
+
+      await submitMarineLicenceController.handler(
+        {
+          payload: { id: mockMarineLicenceId, ...mockAuditPayload },
+          db: mockDb,
+          locker: mockLocker,
+          auth: mockAuth,
+          logger: mockLogger
+        },
+        mockHandler
+      )
+      await flushPromises()
+
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.stringContaining(
+          'Failed to insert Dynamics queue entry for MLA/2025/10001'
+        )
+      )
+    })
   })
 
   describe('Error Handling - Database Operations', () => {

--- a/src/marine-licences/api/controllers/submit-marine-licence.test.js
+++ b/src/marine-licences/api/controllers/submit-marine-licence.test.js
@@ -14,10 +14,7 @@ import { config } from '../../../config.js'
 import { sendEmailConfirmation } from '../../../shared/helpers/send-email-confirmation.js'
 import { updateCoastalOperationsAreas } from '../../../shared/common/helpers/geo/update-coastal-operations-areas.js'
 import { updateMarinePlanningAreas } from '../../../shared/common/helpers/geo/update-marine-planning-areas.js'
-
-// Flush all pending microtasks and macrotasks so the fire-and-forget geo
-// background work completes before asserting.
-const flushPromises = () => new Promise((resolve) => setTimeout(resolve, 0))
+import { flushPromises } from '../../../../tests/test-helpers.js'
 
 vi.mock('../../../shared/helpers/reference-generator.js')
 vi.mock('../helpers/createTaskList.js')
@@ -693,6 +690,7 @@ describe('POST /marine-licence/submit', () => {
       }
 
       await submitMarineLicenceController.handler(mockRequest, mockHandler)
+      await flushPromises()
 
       expect(addToDynamicsQueue).toHaveBeenCalledWith({
         request: mockRequest,

--- a/src/marine-licences/api/controllers/submit-marine-licence.test.js
+++ b/src/marine-licences/api/controllers/submit-marine-licence.test.js
@@ -12,12 +12,20 @@ import {
 } from '../../../shared/common/constants/request-queue.js'
 import { config } from '../../../config.js'
 import { sendEmailConfirmation } from '../../../shared/helpers/send-email-confirmation.js'
+import { updateCoastalOperationsAreas } from '../../../shared/common/helpers/geo/update-coastal-operations-areas.js'
+import { updateMarinePlanningAreas } from '../../../shared/common/helpers/geo/update-marine-planning-areas.js'
+
+// Flush all pending microtasks and macrotasks so the fire-and-forget geo
+// background work completes before asserting.
+const flushPromises = () => new Promise((resolve) => setTimeout(resolve, 0))
 
 vi.mock('../../../shared/helpers/reference-generator.js')
 vi.mock('../helpers/createTaskList.js')
 vi.mock('../../../shared/common/helpers/dynamics/dynamics-processor.js')
 vi.mock('../../../config.js')
 vi.mock('../../../shared/helpers/send-email-confirmation.js')
+vi.mock('../../../shared/common/helpers/geo/update-coastal-operations-areas.js')
+vi.mock('../../../shared/common/helpers/geo/update-marine-planning-areas.js')
 
 describe('POST /marine-licence/submit', () => {
   let mockDb
@@ -102,6 +110,8 @@ describe('POST /marine-licence/submit', () => {
     })
     vi.mocked(addToDynamicsQueue).mockResolvedValue(undefined)
     vi.mocked(sendEmailConfirmation).mockResolvedValue(undefined)
+    vi.mocked(updateCoastalOperationsAreas).mockResolvedValue([])
+    vi.mocked(updateMarinePlanningAreas).mockResolvedValue([])
   })
 
   describe('Payload Validation', () => {
@@ -531,6 +541,123 @@ describe('POST /marine-licence/submit', () => {
       ).rejects.toThrow(
         Boom.internal(
           'Error submitting marine licence: Database connection failed'
+        )
+      )
+    })
+  })
+
+  describe('Geo Area Background Work', () => {
+    it('should update coastal operations areas and marine plan areas against the marine-licences collection', async () => {
+      const mockMarineLicence = {
+        _id: ObjectId.createFromHexString(mockMarineLicenceId),
+        contactId: 'test-contact-id',
+        projectName: 'Test Marine Project'
+      }
+
+      mockMarineLicencesCollection.findOne.mockResolvedValue(mockMarineLicence)
+      mockMarineLicencesCollection.updateOne.mockResolvedValue({
+        matchedCount: 1
+      })
+
+      await submitMarineLicenceController.handler(
+        {
+          payload: { id: mockMarineLicenceId, ...mockAuditPayload },
+          db: mockDb,
+          locker: mockLocker,
+          auth: mockAuth,
+          logger: mockLogger
+        },
+        mockHandler
+      )
+      await flushPromises()
+
+      expect(updateCoastalOperationsAreas).toHaveBeenCalledWith(
+        mockMarineLicence,
+        mockDb,
+        {
+          updatedAt: mockAuditPayload.updatedAt,
+          updatedBy: mockAuditPayload.updatedBy,
+          collectionName: 'marine-licences'
+        }
+      )
+
+      expect(updateMarinePlanningAreas).toHaveBeenCalledWith(
+        mockMarineLicence,
+        mockDb,
+        {
+          updatedAt: mockAuditPayload.updatedAt,
+          updatedBy: mockAuditPayload.updatedBy,
+          collectionName: 'marine-licences'
+        }
+      )
+    })
+
+    it('should log and not throw when updating coastal operations areas fails', async () => {
+      const mockMarineLicence = {
+        _id: ObjectId.createFromHexString(mockMarineLicenceId),
+        contactId: 'test-contact-id',
+        projectName: 'Test Marine Project'
+      }
+
+      mockMarineLicencesCollection.findOne.mockResolvedValue(mockMarineLicence)
+      mockMarineLicencesCollection.updateOne.mockResolvedValue({
+        matchedCount: 1
+      })
+      vi.mocked(updateCoastalOperationsAreas).mockRejectedValueOnce(
+        new Error('Coastal areas lookup failed')
+      )
+
+      await submitMarineLicenceController.handler(
+        {
+          payload: { id: mockMarineLicenceId, ...mockAuditPayload },
+          db: mockDb,
+          locker: mockLocker,
+          auth: mockAuth,
+          logger: mockLogger
+        },
+        mockHandler
+      )
+      await flushPromises()
+
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.stringContaining(
+          'Failed to update coastal operations areas for MLA/2025/10001'
+        )
+      )
+    })
+
+    it('should log and not throw when updating marine plan areas fails', async () => {
+      const mockMarineLicence = {
+        _id: ObjectId.createFromHexString(mockMarineLicenceId),
+        contactId: 'test-contact-id',
+        projectName: 'Test Marine Project'
+      }
+
+      mockMarineLicencesCollection.findOne.mockResolvedValue(mockMarineLicence)
+      mockMarineLicencesCollection.updateOne.mockResolvedValue({
+        matchedCount: 1
+      })
+      vi.mocked(updateMarinePlanningAreas).mockRejectedValueOnce(
+        new Error('Marine plan areas lookup failed')
+      )
+
+      await submitMarineLicenceController.handler(
+        {
+          payload: { id: mockMarineLicenceId, ...mockAuditPayload },
+          db: mockDb,
+          locker: mockLocker,
+          auth: mockAuth,
+          logger: mockLogger
+        },
+        mockHandler
+      )
+      await flushPromises()
+
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.stringContaining(
+          'Failed to update marine plan areas for MLA/2025/10001'
         )
       )
     })

--- a/src/shared/common/helpers/dynamics/dynamics-client.js
+++ b/src/shared/common/helpers/dynamics/dynamics-client.js
@@ -312,6 +312,8 @@ export const sendMarineLicenceToDynamics = async (
     reference: applicationReferenceNumber,
     feeBand,
     applicationUrl: `${frontEndBaseUrl}/view-marine-licence-details/${marineLicence._id}`,
+    marinePlanAreas: marineLicence.marinePlanAreas ?? [],
+    coastalOperationsAreas: marineLicence.coastalOperationsAreas ?? [],
     ...(marineLicence.organisation?.id
       ? { applicantOrganisationId: marineLicence.organisation.id }
       : {}),

--- a/src/shared/common/helpers/dynamics/dynamics-client.test.js
+++ b/src/shared/common/helpers/dynamics/dynamics-client.test.js
@@ -437,6 +437,8 @@ describe('Dynamics Client', () => {
             applicantOrganisationId: 'test-org-id',
             applicationUrl:
               'http://localhost/view-marine-licence-details/ml-123',
+            marinePlanAreas: [],
+            coastalOperationsAreas: [],
             status: 'SUBMITTED'
           },
           headers: {
@@ -470,12 +472,35 @@ describe('Dynamics Client', () => {
             applicantOrganisationId: 'test-org-id',
             applicationUrl:
               'http://localhost/view-marine-licence-details/ml-123',
+            marinePlanAreas: [],
+            coastalOperationsAreas: [],
             status: 'SUBMITTED'
           },
           headers: {
             Authorization: 'Bearer test-access-token',
             'Content-Type': 'application/json'
           }
+        })
+      )
+    })
+
+    it('should include marinePlanAreas and coastalOperationsAreas when present on the marine licence', async () => {
+      mockServer.db.collection().findOne.mockResolvedValue({
+        ...mockMarineLicence,
+        marinePlanAreas: [{ name: 'South Marine Plan Area' }],
+        coastalOperationsAreas: [{ name: 'Coastal Ops Area 1' }]
+      })
+
+      await sendMarineLicenceToDynamics(
+        mockServer,
+        mockAccessToken,
+        mockQueueItem
+      )
+
+      expect(mockWreckPost.mock.calls[0][1].payload).toEqual(
+        expect.objectContaining({
+          marinePlanAreas: [{ name: 'South Marine Plan Area' }],
+          coastalOperationsAreas: [{ name: 'Coastal Ops Area 1' }]
         })
       )
     })

--- a/src/shared/common/helpers/geo/update-coastal-operations-areas.js
+++ b/src/shared/common/helpers/geo/update-coastal-operations-areas.js
@@ -1,14 +1,11 @@
 import { parseGeoAreas } from './geo-parse.js'
 import { createLogger } from '../logging/logger.js'
-import {
-  collectionCoastalOperationsAreas,
-  collectionExemptions
-} from '../../constants/db-collections.js'
+import { collectionCoastalOperationsAreas } from '../../constants/db-collections.js'
 
 export const updateCoastalOperationsAreas = async (
-  exemption,
+  project,
   db,
-  { updatedAt, updatedBy }
+  { updatedAt, updatedBy, collectionName }
 ) => {
   const logger = createLogger()
 
@@ -24,13 +21,13 @@ export const updateCoastalOperationsAreas = async (
 
   const result =
     coastalOperationsAreasCount > 0
-      ? await parseGeoAreas(exemption, db, collectionCoastalOperationsAreas, {
+      ? await parseGeoAreas(project, db, collectionCoastalOperationsAreas, {
           displayName: 'Coastal Operations Areas'
         })
       : []
 
-  await db.collection(collectionExemptions).updateOne(
-    { _id: exemption._id },
+  await db.collection(collectionName).updateOne(
+    { _id: project._id },
     {
       $set: { coastalOperationsAreas: result, updatedAt, updatedBy }
     }

--- a/src/shared/common/helpers/geo/update-coastal-operations-areas.js
+++ b/src/shared/common/helpers/geo/update-coastal-operations-areas.js
@@ -1,3 +1,4 @@
+import Boom from '@hapi/boom'
 import { parseGeoAreas } from './geo-parse.js'
 import { createLogger } from '../logging/logger.js'
 import { collectionCoastalOperationsAreas } from '../../constants/db-collections.js'
@@ -7,6 +8,12 @@ export const updateCoastalOperationsAreas = async (
   db,
   { updatedAt, updatedBy, collectionName }
 ) => {
+  if (!collectionName) {
+    throw Boom.badImplementation(
+      'A collection name is required to update Coastal Operations Areas'
+    )
+  }
+
   const logger = createLogger()
 
   const coastalOperationsAreasCount = await db

--- a/src/shared/common/helpers/geo/update-coastal-operations-areas.test.js
+++ b/src/shared/common/helpers/geo/update-coastal-operations-areas.test.js
@@ -108,4 +108,22 @@ describe('updateCoastalOperationsAreas', () => {
 
     expect(mockDb.collection).toHaveBeenCalledWith('marine-licences')
   })
+
+  test('should throw when collectionName is not provided', async () => {
+    const mockExemption = {
+      _id: 'test-exemption-id',
+      location: { coordinates: [1, 2] }
+    }
+
+    await expect(
+      updateCoastalOperationsAreas(mockExemption, mockDb, {
+        updatedAt: mockUpdatedAt,
+        updatedBy: mockUpdatedBy
+      })
+    ).rejects.toThrow(
+      'A collection name is required to update Coastal Operations Areas'
+    )
+
+    expect(mockDb.collection).not.toHaveBeenCalled()
+  })
 })

--- a/src/shared/common/helpers/geo/update-coastal-operations-areas.test.js
+++ b/src/shared/common/helpers/geo/update-coastal-operations-areas.test.js
@@ -38,7 +38,8 @@ describe('updateCoastalOperationsAreas', () => {
 
     await updateCoastalOperationsAreas(mockExemption, mockDb, {
       updatedAt: mockUpdatedAt,
-      updatedBy: mockUpdatedBy
+      updatedBy: mockUpdatedBy,
+      collectionName: 'exemptions'
     })
 
     expect(parseGeoAreas).toHaveBeenCalledWith(
@@ -58,6 +59,8 @@ describe('updateCoastalOperationsAreas', () => {
         }
       }
     )
+
+    expect(mockDb.collection).toHaveBeenCalledWith('exemptions')
   })
 
   test('should update exemption but skip parsing when no Coastal Operations Areas exist in collection', async () => {
@@ -71,7 +74,8 @@ describe('updateCoastalOperationsAreas', () => {
 
     await updateCoastalOperationsAreas(mockExemption, mockDb, {
       updatedAt: mockUpdatedAt,
-      updatedBy: mockUpdatedBy
+      updatedBy: mockUpdatedBy,
+      collectionName: 'exemptions'
     })
 
     expect(parseMock).not.toHaveBeenCalled()
@@ -86,5 +90,22 @@ describe('updateCoastalOperationsAreas', () => {
         }
       }
     )
+  })
+
+  test('should write result to the provided collection (e.g. marine licences)', async () => {
+    const mockMarineLicence = {
+      _id: 'test-marine-licence-id',
+      location: { coordinates: [1, 2] }
+    }
+
+    vi.mocked(parseGeoAreas).mockResolvedValue(mockCoastalAreas)
+
+    await updateCoastalOperationsAreas(mockMarineLicence, mockDb, {
+      updatedAt: mockUpdatedAt,
+      updatedBy: mockUpdatedBy,
+      collectionName: 'marine-licences'
+    })
+
+    expect(mockDb.collection).toHaveBeenCalledWith('marine-licences')
   })
 })

--- a/src/shared/common/helpers/geo/update-marine-planning-areas.js
+++ b/src/shared/common/helpers/geo/update-marine-planning-areas.js
@@ -1,14 +1,11 @@
 import { parseGeoAreas } from './geo-parse.js'
 import { createLogger } from '../logging/logger.js'
-import {
-  collectionExemptions,
-  collectionMarinePlanAreas
-} from '../../constants/db-collections.js'
+import { collectionMarinePlanAreas } from '../../constants/db-collections.js'
 
 export const updateMarinePlanningAreas = async (
-  exemption,
+  project,
   db,
-  { updatedAt, updatedBy }
+  { updatedAt, updatedBy, collectionName }
 ) => {
   const logger = createLogger()
 
@@ -24,13 +21,13 @@ export const updateMarinePlanningAreas = async (
 
   const result =
     marinePlanAreasCount > 0
-      ? await parseGeoAreas(exemption, db, collectionMarinePlanAreas, {
+      ? await parseGeoAreas(project, db, collectionMarinePlanAreas, {
           displayName: 'Marine Plan Areas'
         })
       : []
 
-  await db.collection(collectionExemptions).updateOne(
-    { _id: exemption._id },
+  await db.collection(collectionName).updateOne(
+    { _id: project._id },
     {
       $set: { marinePlanAreas: result, updatedAt, updatedBy }
     }

--- a/src/shared/common/helpers/geo/update-marine-planning-areas.js
+++ b/src/shared/common/helpers/geo/update-marine-planning-areas.js
@@ -1,3 +1,4 @@
+import Boom from '@hapi/boom'
 import { parseGeoAreas } from './geo-parse.js'
 import { createLogger } from '../logging/logger.js'
 import { collectionMarinePlanAreas } from '../../constants/db-collections.js'
@@ -7,6 +8,12 @@ export const updateMarinePlanningAreas = async (
   db,
   { updatedAt, updatedBy, collectionName }
 ) => {
+  if (!collectionName) {
+    throw Boom.badImplementation(
+      'A collection name is required to update Marine Plan Areas'
+    )
+  }
+
   const logger = createLogger()
 
   const marinePlanAreasCount = await db

--- a/src/shared/common/helpers/geo/update-marine-planning-areas.test.js
+++ b/src/shared/common/helpers/geo/update-marine-planning-areas.test.js
@@ -108,4 +108,22 @@ describe('updateMarinePlanningAreas', () => {
 
     expect(mockDb.collection).toHaveBeenCalledWith('marine-licences')
   })
+
+  test('should throw when collectionName is not provided', async () => {
+    const mockExemption = {
+      _id: 'test-exemption-id',
+      location: { coordinates: [1, 2] }
+    }
+
+    await expect(
+      updateMarinePlanningAreas(mockExemption, mockDb, {
+        updatedAt: mockUpdatedAt,
+        updatedBy: mockUpdatedBy
+      })
+    ).rejects.toThrow(
+      'A collection name is required to update Marine Plan Areas'
+    )
+
+    expect(mockDb.collection).not.toHaveBeenCalled()
+  })
 })

--- a/src/shared/common/helpers/geo/update-marine-planning-areas.test.js
+++ b/src/shared/common/helpers/geo/update-marine-planning-areas.test.js
@@ -38,7 +38,8 @@ describe('updateMarinePlanningAreas', () => {
 
     await updateMarinePlanningAreas(mockExemption, mockDb, {
       updatedAt: mockUpdatedAt,
-      updatedBy: mockUpdatedBy
+      updatedBy: mockUpdatedBy,
+      collectionName: 'exemptions'
     })
 
     expect(parseGeoAreas).toHaveBeenCalledWith(
@@ -58,6 +59,8 @@ describe('updateMarinePlanningAreas', () => {
         }
       }
     )
+
+    expect(mockDb.collection).toHaveBeenCalledWith('exemptions')
   })
 
   test('should update exemption but skip parsing when no Marine Plan areas exist in collection', async () => {
@@ -71,7 +74,8 @@ describe('updateMarinePlanningAreas', () => {
 
     await updateMarinePlanningAreas(mockExemption, mockDb, {
       updatedAt: mockUpdatedAt,
-      updatedBy: mockUpdatedBy
+      updatedBy: mockUpdatedBy,
+      collectionName: 'exemptions'
     })
 
     expect(parseMock).not.toHaveBeenCalled()
@@ -86,5 +90,22 @@ describe('updateMarinePlanningAreas', () => {
         }
       }
     )
+  })
+
+  test('should write result to the provided collection (e.g. marine licences)', async () => {
+    const mockMarineLicence = {
+      _id: 'test-marine-licence-id',
+      location: { coordinates: [1, 2] }
+    }
+
+    vi.mocked(parseGeoAreas).mockResolvedValue(mockMarinePlanAreas)
+
+    await updateMarinePlanningAreas(mockMarineLicence, mockDb, {
+      updatedAt: mockUpdatedAt,
+      updatedBy: mockUpdatedBy,
+      collectionName: 'marine-licences'
+    })
+
+    expect(mockDb.collection).toHaveBeenCalledWith('marine-licences')
   })
 })

--- a/tests/test-helpers.js
+++ b/tests/test-helpers.js
@@ -1,0 +1,2 @@
+export const flushPromises = () =>
+  new Promise((resolve) => setTimeout(resolve, 0))


### PR DESCRIPTION
## Description
 
Add Coastal Operations Areas and Marine Plan Areas to Marine Licence.

## Changes

- marinePlanAreas and coastalOperationsAreas added to Marine Licence on Submit
- Same functionality as used on Exemptions, so here we make it generic using collectionName