### PR TITLE
Add duration logging for employee GET /projects

### DIFF
--- a/src/shared/api/projects/controllers/get-projects.js
+++ b/src/shared/api/projects/controllers/get-projects.js
@@ -10,6 +10,9 @@ import {
 } from '../../../constants/project-status.js'
 import { getOrganisationDetailsFromAuthToken } from '../../../helpers/get-organisation-from-token.js'
 import { batchGetContactNames } from '../../../common/helpers/dynamics/get-contact-details.js'
+import { createLogger } from '../../../common/helpers/logging/logger.js'
+
+const logger = createLogger()
 
 const transformProjectBase = (project, projectType) => {
   const { _id, projectName, applicationReference, status, submittedAt } =
@@ -62,6 +65,7 @@ export const sortByStatus = (a, b) => {
 const getEmployeeProjects = async (db, organisationId, contactId) => {
   const orgFilter = { 'organisation.id': organisationId }
 
+  const dbStartedAt = Date.now()
   const [empExemptions, empMarineLicences] = await Promise.all([
     db
       .collection(collectionExemptions)
@@ -74,6 +78,15 @@ const getEmployeeProjects = async (db, organisationId, contactId) => {
       .sort({ projectName: 1 })
       .toArray()
   ])
+  logger.info(
+    {
+      durationMs: Date.now() - dbStartedAt,
+      operation: 'getEmployeeProjects.db',
+      exemptionCount: empExemptions.length,
+      marineLicenceCount: empMarineLicences.length
+    },
+    'Employee projects database query completed'
+  )
 
   const contactIds = [
     ...new Set(

--- a/src/shared/api/projects/controllers/get-projects.js
+++ b/src/shared/api/projects/controllers/get-projects.js
@@ -13,6 +13,7 @@ import { batchGetContactNames } from '../../../common/helpers/dynamics/get-conta
 import { createLogger } from '../../../common/helpers/logging/logger.js'
 
 const logger = createLogger()
+const logSystem = 'Projects:GetProjects'
 
 const transformProjectBase = (project, projectType) => {
   const { _id, projectName, applicationReference, status, submittedAt } =
@@ -79,13 +80,7 @@ const getEmployeeProjects = async (db, organisationId, contactId) => {
       .toArray()
   ])
   logger.info(
-    {
-      durationMs: Date.now() - dbStartedAt,
-      operation: 'getEmployeeProjects.db',
-      exemptionCount: empExemptions.length,
-      marineLicenceCount: empMarineLicences.length
-    },
-    'Employee projects database query completed'
+    `${logSystem}: Employee projects database query completed in ${Date.now() - dbStartedAt}ms (exemptions: ${empExemptions.length}, marineLicences: ${empMarineLicences.length})`
   )
 
   const contactIds = [

--- a/src/shared/api/projects/controllers/get-projects.test.js
+++ b/src/shared/api/projects/controllers/get-projects.test.js
@@ -6,6 +6,7 @@ import {
   collectionExemptions,
   collectionMarineLicences
 } from '../../../common/constants/db-collections.js'
+import { createLogger } from '../../../common/helpers/logging/logger.js'
 
 vi.mock('../../../common/helpers/dynamics/get-contact-details.js', () => ({
   batchGetContactNames: vi.fn().mockResolvedValue({})
@@ -19,6 +20,7 @@ describe('getProjectsController', () => {
   let mockMarineLicenceCollection
   const testContactId = 'contact-123-abc'
   const testOrgId = '27d48d6c-6e94-f011-b4cc-000d3ac28f39'
+  const logger = createLogger()
 
   const createAuthWithOrg = (organisationId = testOrgId) => ({
     credentials: {
@@ -107,7 +109,10 @@ describe('getProjectsController', () => {
     }
   ]
 
-  beforeEach(() => setupMocks(mockExemptions, mockMarineLicences))
+  beforeEach(() => {
+    setupMocks(mockExemptions, mockMarineLicences)
+    vi.spyOn(logger, 'info')
+  })
 
   describe('handler', () => {
     it('should query employee collection with organisation filter', async () => {
@@ -119,6 +124,15 @@ describe('getProjectsController', () => {
       expect(mockMarineLicenceCollection.find).toHaveBeenCalledWith({
         'organisation.id': testOrgId
       })
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.objectContaining({
+          durationMs: expect.any(Number),
+          operation: 'getEmployeeProjects.db',
+          exemptionCount: 2,
+          marineLicenceCount: 1
+        }),
+        'Employee projects database query completed'
+      )
     })
 
     it('should query citizen collection with contactId and no-org filter', async () => {

--- a/src/shared/api/projects/controllers/get-projects.test.js
+++ b/src/shared/api/projects/controllers/get-projects.test.js
@@ -125,13 +125,9 @@ describe('getProjectsController', () => {
         'organisation.id': testOrgId
       })
       expect(logger.info).toHaveBeenCalledWith(
-        expect.objectContaining({
-          durationMs: expect.any(Number),
-          operation: 'getEmployeeProjects.db',
-          exemptionCount: 2,
-          marineLicenceCount: 1
-        }),
-        'Employee projects database query completed'
+        expect.stringMatching(
+          /^Projects:GetProjects: Employee projects database query completed in \d+ms \(exemptions: 2, marineLicences: 1\)$/
+        )
       )
     })
 

--- a/src/shared/common/helpers/dynamics/get-contact-details.js
+++ b/src/shared/common/helpers/dynamics/get-contact-details.js
@@ -66,6 +66,10 @@ const fetchContactBatch = async (batchIds, baseUrl) => {
     'Dynamics access token retrieved for batch contact details'
   )
 
+  logger.info(
+    `Dynamics batch contact details requested for ${batchIds.length} contacts`
+  )
+
   const filterClauses = batchIds
     .map((id) => `contactid eq '${escapeODataString(id)}'`)
     .join(' or ')
@@ -100,7 +104,6 @@ export const getContactNameById = async ({ contactId }) => {
     return null
   }
 
-  logger.info(`Dynamics contact details requested for ID ${contactId}`)
   try {
     const {
       contactDetails: { apiUrl },
@@ -111,6 +114,7 @@ export const getContactNameById = async ({ contactId }) => {
     }
     const endpoint = apiUrl.replace('{{contactId}}', contactId)
     const accessToken = await getDynamicsAccessToken({ type: 'contactDetails' })
+    logger.info(`Dynamics contact details requested for ID ${contactId}`)
     const response = await Wreck.get(endpoint, {
       headers: dynamicsHeaders(accessToken)
     })
@@ -149,10 +153,6 @@ export const batchGetContactNames = async (contactIds) => {
     logger.warn('No valid contact IDs provided for batch lookup')
     return {}
   }
-
-  logger.info(
-    `Dynamics batch contact details requested for ${validIds.length} contacts`
-  )
 
   const results = {}
   const batchStartedAt = Date.now()

--- a/src/shared/common/helpers/dynamics/get-contact-details.js
+++ b/src/shared/common/helpers/dynamics/get-contact-details.js
@@ -54,16 +54,36 @@ const filterValidContactIds = (contactIds) => {
 }
 
 const fetchContactBatch = async (batchIds, baseUrl) => {
+  const tokenStartedAt = Date.now()
   const accessToken = await getDynamicsAccessToken({ type: 'contactDetails' })
+  logger.info(
+    {
+      durationMs: Date.now() - tokenStartedAt,
+      service: 'dynamics',
+      operation: 'dynamics.token',
+      count: batchIds.length
+    },
+    'Dynamics access token retrieved for batch contact details'
+  )
 
   const filterClauses = batchIds
     .map((id) => `contactid eq '${escapeODataString(id)}'`)
     .join(' or ')
   const endpoint = `${baseUrl}/contacts?$select=fullname,contactid&$filter=${filterClauses}`
 
+  const httpStartedAt = Date.now()
   const response = await Wreck.get(endpoint, {
     headers: dynamicsHeaders(accessToken)
   })
+  logger.info(
+    {
+      durationMs: Date.now() - httpStartedAt,
+      service: 'dynamics',
+      operation: 'dynamics.batchContacts',
+      count: batchIds.length
+    },
+    'Dynamics batch contact details request completed'
+  )
 
   const parsedData = parseResponse(response)
   const contacts = parsedData.value || []
@@ -135,6 +155,7 @@ export const batchGetContactNames = async (contactIds) => {
   )
 
   const results = {}
+  const batchStartedAt = Date.now()
 
   try {
     for (let i = 0; i < validIds.length; i += MAX_BATCH_SIZE) {
@@ -146,6 +167,15 @@ export const batchGetContactNames = async (contactIds) => {
       })
       Object.assign(results, batchResult)
     }
+    logger.info(
+      {
+        durationMs: Date.now() - batchStartedAt,
+        service: 'dynamics',
+        operation: 'dynamics.batchGetContactNames',
+        count: validIds.length
+      },
+      'Dynamics batch contact details completed'
+    )
     return results
   } catch (err) {
     logger.error(

--- a/src/shared/common/helpers/dynamics/get-contact-details.js
+++ b/src/shared/common/helpers/dynamics/get-contact-details.js
@@ -5,6 +5,7 @@ import { retryAsyncOperation } from '../retry-async-operation.js'
 import { config } from '../../../../config.js'
 
 const logger = createLogger()
+const logSystem = 'Dynamics:ContactDetails'
 
 const isValidGuid = (guid) => {
   const guidRegex =
@@ -57,17 +58,11 @@ const fetchContactBatch = async (batchIds, baseUrl) => {
   const tokenStartedAt = Date.now()
   const accessToken = await getDynamicsAccessToken({ type: 'contactDetails' })
   logger.info(
-    {
-      durationMs: Date.now() - tokenStartedAt,
-      service: 'dynamics',
-      operation: 'dynamics.token',
-      count: batchIds.length
-    },
-    'Dynamics access token retrieved for batch contact details'
+    `${logSystem}: Access token retrieved for batch contact details in ${Date.now() - tokenStartedAt}ms (count: ${batchIds.length})`
   )
 
   logger.info(
-    `Dynamics batch contact details requested for ${batchIds.length} contacts`
+    `${logSystem}: Batch contact details requested for ${batchIds.length} contacts`
   )
 
   const filterClauses = batchIds
@@ -80,13 +75,7 @@ const fetchContactBatch = async (batchIds, baseUrl) => {
     headers: dynamicsHeaders(accessToken)
   })
   logger.info(
-    {
-      durationMs: Date.now() - httpStartedAt,
-      service: 'dynamics',
-      operation: 'dynamics.batchContacts',
-      count: batchIds.length
-    },
-    'Dynamics batch contact details request completed'
+    `${logSystem}: Batch contact details request completed in ${Date.now() - httpStartedAt}ms (count: ${batchIds.length})`
   )
 
   const parsedData = parseResponse(response)
@@ -114,7 +103,7 @@ export const getContactNameById = async ({ contactId }) => {
     }
     const endpoint = apiUrl.replace('{{contactId}}', contactId)
     const accessToken = await getDynamicsAccessToken({ type: 'contactDetails' })
-    logger.info(`Dynamics contact details requested for ID ${contactId}`)
+    logger.info(`${logSystem}: Contact details requested for ID ${contactId}`)
     const response = await Wreck.get(endpoint, {
       headers: dynamicsHeaders(accessToken)
     })
@@ -168,13 +157,7 @@ export const batchGetContactNames = async (contactIds) => {
       Object.assign(results, batchResult)
     }
     logger.info(
-      {
-        durationMs: Date.now() - batchStartedAt,
-        service: 'dynamics',
-        operation: 'dynamics.batchGetContactNames',
-        count: validIds.length
-      },
-      'Dynamics batch contact details completed'
+      `${logSystem}: Batch contact details completed in ${Date.now() - batchStartedAt}ms (count: ${validIds.length})`
     )
     return results
   } catch (err) {

--- a/src/shared/common/helpers/dynamics/get-contact-details.test.js
+++ b/src/shared/common/helpers/dynamics/get-contact-details.test.js
@@ -205,6 +205,15 @@ describe('batchGetContactNames', () => {
       expect(logger.info).toHaveBeenCalledWith(
         'Dynamics batch contact details requested for 2 contacts'
       )
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.objectContaining({
+          durationMs: expect.any(Number),
+          service: 'dynamics',
+          operation: 'dynamics.batchGetContactNames',
+          count: 2
+        }),
+        'Dynamics batch contact details completed'
+      )
     })
 
     it('should call retryAsyncOperation with correct parameters', async () => {
@@ -329,6 +338,24 @@ describe('batchGetContactNames - fetchContactBatch integration', () => {
       [validGuid1]: 'John Smith',
       [validGuid2]: 'Jane Doe'
     })
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.objectContaining({
+        durationMs: expect.any(Number),
+        service: 'dynamics',
+        operation: 'dynamics.token',
+        count: 2
+      }),
+      'Dynamics access token retrieved for batch contact details'
+    )
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.objectContaining({
+        durationMs: expect.any(Number),
+        service: 'dynamics',
+        operation: 'dynamics.batchContacts',
+        count: 2
+      }),
+      'Dynamics batch contact details request completed'
+    )
   })
 
   it('should handle contacts with missing fullname', async () => {

--- a/src/shared/common/helpers/dynamics/get-contact-details.test.js
+++ b/src/shared/common/helpers/dynamics/get-contact-details.test.js
@@ -203,9 +203,6 @@ describe('batchGetContactNames', () => {
         [validGuid2]: 'Jane Doe'
       })
       expect(logger.info).toHaveBeenCalledWith(
-        'Dynamics batch contact details requested for 2 contacts'
-      )
-      expect(logger.info).toHaveBeenCalledWith(
         expect.objectContaining({
           durationMs: expect.any(Number),
           service: 'dynamics',
@@ -346,6 +343,9 @@ describe('batchGetContactNames - fetchContactBatch integration', () => {
         count: 2
       }),
       'Dynamics access token retrieved for batch contact details'
+    )
+    expect(logger.info).toHaveBeenCalledWith(
+      'Dynamics batch contact details requested for 2 contacts'
     )
     expect(logger.info).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/src/shared/common/helpers/dynamics/get-contact-details.test.js
+++ b/src/shared/common/helpers/dynamics/get-contact-details.test.js
@@ -59,7 +59,7 @@ describe('Get contact name from Dynamics 365', () => {
       }
     )
     expect(logger.info).toHaveBeenCalledWith(
-      `Dynamics contact details requested for ID ${contactId}`
+      `Dynamics:ContactDetails: Contact details requested for ID ${contactId}`
     )
   })
 
@@ -203,13 +203,9 @@ describe('batchGetContactNames', () => {
         [validGuid2]: 'Jane Doe'
       })
       expect(logger.info).toHaveBeenCalledWith(
-        expect.objectContaining({
-          durationMs: expect.any(Number),
-          service: 'dynamics',
-          operation: 'dynamics.batchGetContactNames',
-          count: 2
-        }),
-        'Dynamics batch contact details completed'
+        expect.stringMatching(
+          /^Dynamics:ContactDetails: Batch contact details completed in \d+ms \(count: 2\)$/
+        )
       )
     })
 
@@ -336,25 +332,17 @@ describe('batchGetContactNames - fetchContactBatch integration', () => {
       [validGuid2]: 'Jane Doe'
     })
     expect(logger.info).toHaveBeenCalledWith(
-      expect.objectContaining({
-        durationMs: expect.any(Number),
-        service: 'dynamics',
-        operation: 'dynamics.token',
-        count: 2
-      }),
-      'Dynamics access token retrieved for batch contact details'
+      expect.stringMatching(
+        /^Dynamics:ContactDetails: Access token retrieved for batch contact details in \d+ms \(count: 2\)$/
+      )
     )
     expect(logger.info).toHaveBeenCalledWith(
-      'Dynamics batch contact details requested for 2 contacts'
+      'Dynamics:ContactDetails: Batch contact details requested for 2 contacts'
     )
     expect(logger.info).toHaveBeenCalledWith(
-      expect.objectContaining({
-        durationMs: expect.any(Number),
-        service: 'dynamics',
-        operation: 'dynamics.batchContacts',
-        count: 2
-      }),
-      'Dynamics batch contact details request completed'
+      expect.stringMatching(
+        /^Dynamics:ContactDetails: Batch contact details request completed in \d+ms \(count: 2\)$/
+      )
     )
   })
 


### PR DESCRIPTION
Summary

- Add duration logging for employee GET /projects Mongo queries and Dynamics token/contact batch calls
- Fix log order so the token is logged before contact details are requested
- Use CDP-friendly message strings (Dynamics:ContactDetails:, Projects:GetProjects:)
<img width="1490" height="533" alt="Screenshot 2026-07-23 at 15 50 44" src="https://github.com/user-attachments/assets/e7594c7a-353c-4193-b681-4aad85f01653" />
Tested this in cdp as a hot fix as well. This should allow us to narrow down on the slowness issue in production for dynamics contact details end point