### PR TITLE
bug: marine plans explorer url changed

### DIFF
--- a/src/config/marine-plan-policies.js
+++ b/src/config/marine-plan-policies.js
@@ -37,7 +37,7 @@ export const marinePlanPoliciesSchema = {
     doc: 'URL of the GOV.UK marine-plans-explorer policies API (public; same value in all environments)',
     format: String,
     default:
-      'https://environment.data.gov.uk/marine-plans-explorer/api/policies',
+      'https://environment.data.gov.uk/explore-marine-plans/api/policies',
     env: 'GOVUK_MARINE_POLICIES_API_URL'
   },
   arcgisTimeoutMs: {

--- a/src/marine-licences/api/helpers/marine-plan-policies/policy-http.js
+++ b/src/marine-licences/api/helpers/marine-plan-policies/policy-http.js
@@ -27,6 +27,7 @@ export const timedJsonFetch = async ({
       },
       payload: options.body,
       timeout: timeoutMs,
+      redirects: 1,
       ...(maxBytes && { maxBytes }),
       json: true
     }


### PR DESCRIPTION
This PR addresses the fact that the Marine Plans explorer API url changed and also allows for potential future redirects