### PR TITLE
ML-1433 D365 - "Project details" tab - new get end point

### DIFF
--- a/src/marine-licences/api/controllers/get-marine-licence-gateway.integration.test.js
+++ b/src/marine-licences/api/controllers/get-marine-licence-gateway.integration.test.js
@@ -1,0 +1,74 @@
+import { setupTestServer } from '../../../../tests/test-server.js'
+import { ObjectId } from 'mongodb'
+import { mockMarineLicence } from '../../models/test-fixtures.js'
+import { MARINE_LICENCE_STATUS } from '../../constants/marine-licence.js'
+
+vi.mock('../../../shared/services/data-service/blob-service.js', () => ({
+  blobService: {
+    getPresignedUrl: vi.fn()
+  }
+}))
+
+describe('GET /public/marine-licence/mas/{id} - integration tests', async () => {
+  const getServer = await setupTestServer()
+
+  test('returns project fields for a SUBMITTED marine licence', async () => {
+    const publicId = new ObjectId()
+    const marineLicence = {
+      ...mockMarineLicence,
+      _id: publicId,
+      projectName: 'Harbour dredging',
+      projectBackground: 'Maintenance of navigation channel',
+      preferredDates: {
+        start: { month: '08', year: '2026' },
+        end: { month: '11', year: '2026' }
+      },
+      status: MARINE_LICENCE_STATUS.SUBMITTED
+    }
+
+    await globalThis.mockMongo
+      .collection('marine-licences')
+      .insertOne(marineLicence)
+
+    const response = await getServer().inject({
+      method: 'GET',
+      url: `/public/marine-licence/mas/${publicId}`
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect(JSON.parse(response.payload)).toEqual({
+      projectName: 'Harbour dredging',
+      projectBackground: 'Maintenance of navigation channel',
+      preferredLicenceDates: 'August 2026 to November 2026'
+    })
+  })
+
+  test('returns 403 when requesting a DRAFT marine licence', async () => {
+    const draftId = new ObjectId()
+    const marineLicence = {
+      ...mockMarineLicence,
+      _id: draftId,
+      status: MARINE_LICENCE_STATUS.DRAFT
+    }
+
+    await globalThis.mockMongo
+      .collection('marine-licences')
+      .insertOne(marineLicence)
+
+    const response = await getServer().inject({
+      method: 'GET',
+      url: `/public/marine-licence/mas/${draftId}`
+    })
+
+    expect(response.statusCode).toBe(403)
+  })
+
+  test('returns 404 when marine licence does not exist', async () => {
+    const response = await getServer().inject({
+      method: 'GET',
+      url: `/public/marine-licence/mas/${new ObjectId()}`
+    })
+
+    expect(response.statusCode).toBe(404)
+  })
+})

--- a/src/marine-licences/api/controllers/get-marine-licence-gateway.js
+++ b/src/marine-licences/api/controllers/get-marine-licence-gateway.js
@@ -1,0 +1,48 @@
+import Boom from '@hapi/boom'
+import { ObjectId } from 'mongodb'
+import { StatusCodes } from 'http-status-codes'
+import { collectionMarineLicences } from '../../../shared/common/constants/db-collections.js'
+import { notAuthorisedMessage } from '../../../shared/constants/errors.js'
+import { MARINE_LICENCE_STATUS } from '../../constants/marine-licence.js'
+import { getMarineLicence } from '../../models/get-marine-licence.js'
+import { formatPreferredDates } from '../helpers/format-preferred-dates.js'
+
+export const getMarineLicenceGatewayController = {
+  options: {
+    auth: false,
+    validate: {
+      params: getMarineLicence
+    }
+  },
+  handler: async (request, h) => {
+    const { id } = request.params
+
+    const doc = await request.db.collection(collectionMarineLicences).findOne(
+      { _id: ObjectId.createFromHexString(id) },
+      {
+        projection: {
+          projectName: 1,
+          projectBackground: 1,
+          preferredDates: 1,
+          status: 1
+        }
+      }
+    )
+
+    if (!doc) {
+      throw Boom.notFound('Marine licence not found')
+    }
+
+    if (doc.status === MARINE_LICENCE_STATUS.DRAFT) {
+      throw Boom.forbidden(notAuthorisedMessage)
+    }
+
+    return h
+      .response({
+        projectName: doc.projectName ?? null,
+        projectBackground: doc.projectBackground ?? null,
+        preferredLicenceDates: formatPreferredDates(doc.preferredDates)
+      })
+      .code(StatusCodes.OK)
+  }
+}

--- a/src/marine-licences/api/controllers/get-marine-licence-gateway.test.js
+++ b/src/marine-licences/api/controllers/get-marine-licence-gateway.test.js
@@ -1,0 +1,121 @@
+import { getMarineLicenceGatewayController } from './get-marine-licence-gateway.js'
+import { vi } from 'vitest'
+import { MARINE_LICENCE_STATUS } from '../../constants/marine-licence.js'
+import { preferredDates } from '../../models/test-fixtures.js'
+
+describe('GET /public/marine-licence/mas/{id}', () => {
+  const paramsValidator =
+    getMarineLicenceGatewayController.options.validate.params
+  const mockId = '123456789123456789123456'
+
+  let mockedFindOne
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockedFindOne = vi.fn().mockResolvedValue(null)
+    vi.spyOn(global.mockMongo, 'collection').mockImplementation(function () {
+      return { findOne: mockedFindOne }
+    })
+  })
+
+  const mockRequest = (overrides = {}) => ({
+    params: { id: mockId },
+    db: global.mockMongo,
+    logger: { info: vi.fn(), error: vi.fn() },
+    ...overrides
+  })
+
+  describe('Validation', () => {
+    it('should fail if id is missing', () => {
+      const result = paramsValidator.validate({})
+
+      expect(result.error.message).toContain('MARINE_LICENCE_ID_REQUIRED')
+    })
+
+    it('should fail if id has incorrect length', () => {
+      const result = paramsValidator.validate({ id: '123' })
+
+      expect(result.error.message).toContain('MARINE_LICENCE_ID_REQUIRED')
+    })
+
+    it('should fail if id has incorrect characters', () => {
+      const result = paramsValidator.validate({ id: mockId.replace('1', '+') })
+
+      expect(result.error.message).toContain('MARINE_LICENCE_ID_INVALID')
+    })
+  })
+
+  describe('Handler', () => {
+    it('should return 404 if ID does not exist', async () => {
+      const { mockHandler } = global
+
+      mockedFindOne.mockResolvedValue(null)
+
+      await expect(
+        getMarineLicenceGatewayController.handler(mockRequest(), mockHandler)
+      ).rejects.toThrow('Marine licence not found')
+    })
+
+    it('should return forbidden if status is DRAFT', async () => {
+      const { mockHandler } = global
+
+      mockedFindOne.mockResolvedValue({
+        _id: mockId,
+        projectName: 'Test project',
+        projectBackground: 'Background',
+        preferredDates,
+        status: MARINE_LICENCE_STATUS.DRAFT
+      })
+
+      await expect(
+        getMarineLicenceGatewayController.handler(mockRequest(), mockHandler)
+      ).rejects.toThrow('Not authorised to request this resource')
+    })
+
+    it('should return project fields for a non-draft marine licence', async () => {
+      const { mockHandler } = global
+
+      mockedFindOne.mockResolvedValue({
+        _id: mockId,
+        projectName: 'Test project',
+        projectBackground: 'Test project background',
+        preferredDates: {
+          start: { month: '08', year: '2026' },
+          end: { month: '11', year: '2026' }
+        },
+        status: MARINE_LICENCE_STATUS.SUBMITTED
+      })
+
+      await getMarineLicenceGatewayController.handler(
+        mockRequest(),
+        mockHandler
+      )
+
+      expect(mockHandler.response).toHaveBeenCalledWith({
+        projectName: 'Test project',
+        projectBackground: 'Test project background',
+        preferredLicenceDates: 'August 2026 to November 2026'
+      })
+    })
+
+    it('should return nulls when optional fields are missing', async () => {
+      const { mockHandler } = global
+
+      mockedFindOne.mockResolvedValue({
+        _id: mockId,
+        status: MARINE_LICENCE_STATUS.SUBMITTED
+      })
+
+      await getMarineLicenceGatewayController.handler(
+        mockRequest(),
+        mockHandler
+      )
+
+      expect(mockHandler.response).toHaveBeenCalledWith({
+        projectName: null,
+        projectBackground: null,
+        preferredLicenceDates: null
+      })
+    })
+  })
+})

--- a/src/marine-licences/api/gateway-routes.js
+++ b/src/marine-licences/api/gateway-routes.js
@@ -1,4 +1,5 @@
 import { generateCoordinatesCsvPublicController } from './controllers/generate-coordinates-csv-public.js'
+import { getMarineLicenceGatewayController } from './controllers/get-marine-licence-gateway.js'
 import { getWfdDocumentDownloadUrlController } from './controllers/get-wfd-document-download-url.js'
 import { buildWfdDocumentDownloadPathById } from '../constants/water-framework-directive.js'
 
@@ -7,6 +8,11 @@ import { buildWfdDocumentDownloadPathById } from '../constants/water-framework-d
  * Used by D365 and other non-frontend callers via the CDP gateway.
  */
 export const marineLicenceGatewayRoutes = [
+  {
+    method: 'GET',
+    path: '/public/marine-licence/mas/{id}',
+    ...getMarineLicenceGatewayController
+  },
   {
     method: 'GET',
     path: '/public/marine-licence/{id}/generate-coordinates-csv',

--- a/src/marine-licences/api/helpers/format-preferred-dates.js
+++ b/src/marine-licences/api/helpers/format-preferred-dates.js
@@ -1,6 +1,10 @@
 import { format, isValid } from 'date-fns'
 
 const MONTH_YEAR_FORMAT = 'MMMM yyyy'
+const MIN_MONTH = 1
+const MAX_MONTH = 12
+const MIN_FOUR_DIGIT_YEAR = 1000
+const MAX_FOUR_DIGIT_YEAR = 9999
 
 const isValidMonthYear = ({ month, year }) => {
   const monthNumber = Number(month)
@@ -8,11 +12,11 @@ const isValidMonthYear = ({ month, year }) => {
 
   return (
     Number.isInteger(monthNumber) &&
-    monthNumber >= 1 &&
-    monthNumber <= 12 &&
+    monthNumber >= MIN_MONTH &&
+    monthNumber <= MAX_MONTH &&
     Number.isInteger(yearNumber) &&
-    yearNumber >= 1000 &&
-    yearNumber <= 9999
+    yearNumber >= MIN_FOUR_DIGIT_YEAR &&
+    yearNumber <= MAX_FOUR_DIGIT_YEAR
   )
 }
 

--- a/src/marine-licences/api/helpers/format-preferred-dates.js
+++ b/src/marine-licences/api/helpers/format-preferred-dates.js
@@ -1,14 +1,46 @@
-import { format } from 'date-fns'
+import { format, isValid } from 'date-fns'
 
 const MONTH_YEAR_FORMAT = 'MMMM yyyy'
 
-const formatMonthYear = ({ month, year }) =>
-  format(new Date(Number(year), Number(month) - 1, 1), MONTH_YEAR_FORMAT)
+const isValidMonthYear = ({ month, year }) => {
+  const monthNumber = Number(month)
+  const yearNumber = Number(year)
+
+  return (
+    Number.isInteger(monthNumber) &&
+    monthNumber >= 1 &&
+    monthNumber <= 12 &&
+    Number.isInteger(yearNumber) &&
+    yearNumber >= 1000 &&
+    yearNumber <= 9999
+  )
+}
+
+const formatMonthYear = ({ month, year }) => {
+  if (!isValidMonthYear({ month, year })) {
+    return null
+  }
+
+  const date = new Date(Number(year), Number(month) - 1, 1)
+
+  if (!isValid(date)) {
+    return null
+  }
+
+  return format(date, MONTH_YEAR_FORMAT)
+}
 
 export const formatPreferredDates = (preferredDates) => {
   if (!preferredDates?.start || !preferredDates?.end) {
     return null
   }
 
-  return `${formatMonthYear(preferredDates.start)} to ${formatMonthYear(preferredDates.end)}`
+  const start = formatMonthYear(preferredDates.start)
+  const end = formatMonthYear(preferredDates.end)
+
+  if (!start || !end) {
+    return null
+  }
+
+  return `${start} to ${end}`
 }

--- a/src/marine-licences/api/helpers/format-preferred-dates.js
+++ b/src/marine-licences/api/helpers/format-preferred-dates.js
@@ -1,0 +1,14 @@
+import { format } from 'date-fns'
+
+const MONTH_YEAR_FORMAT = 'MMMM yyyy'
+
+const formatMonthYear = ({ month, year }) =>
+  format(new Date(Number(year), Number(month) - 1, 1), MONTH_YEAR_FORMAT)
+
+export const formatPreferredDates = (preferredDates) => {
+  if (!preferredDates?.start || !preferredDates?.end) {
+    return null
+  }
+
+  return `${formatMonthYear(preferredDates.start)} to ${formatMonthYear(preferredDates.end)}`
+}

--- a/src/marine-licences/api/helpers/format-preferred-dates.test.js
+++ b/src/marine-licences/api/helpers/format-preferred-dates.test.js
@@ -32,4 +32,49 @@ describe('formatPreferredDates', () => {
       formatPreferredDates({ end: { month: '11', year: '2026' } })
     ).toBeNull()
   })
+
+  it('returns null for non-numeric month or year', () => {
+    expect(
+      formatPreferredDates({
+        start: { month: 'abc', year: '2026' },
+        end: { month: '11', year: '2026' }
+      })
+    ).toBeNull()
+    expect(
+      formatPreferredDates({
+        start: { month: '08', year: '2026' },
+        end: { month: '11', year: 'abcd' }
+      })
+    ).toBeNull()
+  })
+
+  it('returns null for empty month or year', () => {
+    expect(
+      formatPreferredDates({
+        start: { month: '', year: '2026' },
+        end: { month: '11', year: '2026' }
+      })
+    ).toBeNull()
+    expect(
+      formatPreferredDates({
+        start: { month: '08', year: '2026' },
+        end: { month: '11', year: '' }
+      })
+    ).toBeNull()
+  })
+
+  it('returns null for out-of-range month', () => {
+    expect(
+      formatPreferredDates({
+        start: { month: '13', year: '2026' },
+        end: { month: '11', year: '2026' }
+      })
+    ).toBeNull()
+    expect(
+      formatPreferredDates({
+        start: { month: '08', year: '2026' },
+        end: { month: '0', year: '2026' }
+      })
+    ).toBeNull()
+  })
 })

--- a/src/marine-licences/api/helpers/format-preferred-dates.test.js
+++ b/src/marine-licences/api/helpers/format-preferred-dates.test.js
@@ -1,0 +1,35 @@
+import { formatPreferredDates } from './format-preferred-dates.js'
+
+describe('formatPreferredDates', () => {
+  it('formats start and end as "MMMM yyyy to MMMM yyyy"', () => {
+    expect(
+      formatPreferredDates({
+        start: { month: '08', year: '2026' },
+        end: { month: '11', year: '2026' }
+      })
+    ).toBe('August 2026 to November 2026')
+  })
+
+  it('handles single-digit month strings', () => {
+    expect(
+      formatPreferredDates({
+        start: { month: '1', year: '2027' },
+        end: { month: '12', year: '2027' }
+      })
+    ).toBe('January 2027 to December 2027')
+  })
+
+  it('returns null when preferredDates is missing', () => {
+    expect(formatPreferredDates(null)).toBeNull()
+    expect(formatPreferredDates(undefined)).toBeNull()
+  })
+
+  it('returns null when start or end is missing', () => {
+    expect(
+      formatPreferredDates({ start: { month: '08', year: '2026' } })
+    ).toBeNull()
+    expect(
+      formatPreferredDates({ end: { month: '11', year: '2026' } })
+    ).toBeNull()
+  })
+})

--- a/src/shared/common/helpers/dynamics/dynamics-client.js
+++ b/src/shared/common/helpers/dynamics/dynamics-client.js
@@ -311,6 +311,7 @@ export const sendMarineLicenceToDynamics = async (
 
   const payload = {
     contactid: marineLicence.contactId,
+    marineLicenceId: marineLicence._id.toString(),
     projectName: marineLicence.projectName,
     reference: applicationReferenceNumber,
     feeBand,

--- a/src/shared/common/helpers/dynamics/dynamics-client.test.js
+++ b/src/shared/common/helpers/dynamics/dynamics-client.test.js
@@ -435,6 +435,7 @@ describe('Dynamics Client', () => {
         expect.objectContaining({
           payload: {
             contactid: 'test-contact-id',
+            marineLicenceId: 'ml-123',
             feeBand: '2A',
             projectName: 'Test Marine Project',
             reference: 'MLA/2025/00001',
@@ -478,6 +479,7 @@ describe('Dynamics Client', () => {
         expect.objectContaining({
           payload: {
             contactid: 'test-contact-id',
+            marineLicenceId: 'ml-123',
             feeBand: '2A',
             projectName: 'Test Marine Project',
             reference: 'MLA/2025/00001',


### PR DESCRIPTION
**Summary**

- Include marineLicenceId (Mongo _id) in the Dynamics LCML create payload so MAS can call back into the backend

- Add GET /public/marine-licence/mas/{id} for D365, returning projectName, projectBackground, and preferredLicenceDates (formatted as August 2026 to November 2026)